### PR TITLE
Make server address not case sensitive

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -131,6 +131,8 @@ func (r *routesImpl) FindBackendForServerAddress(serverAddress string) string {
 
 	addressParts := strings.Split(serverAddress, "\x00")
 
+	address := strings.toLower(addressParts[0])
+
 	if r.mappings == nil {
 		return r.defaultRoute
 	} else {
@@ -170,6 +172,8 @@ func (r *routesImpl) DeleteMapping(serverAddress string) bool {
 func (r *routesImpl) CreateMapping(serverAddress string, backend string) {
 	r.Lock()
 	defer r.Unlock()
+
+	serverAddress = strings.toLower(serverAddress)
 
 	logrus.WithFields(logrus.Fields{
 		"serverAddress": serverAddress,


### PR DESCRIPTION
Store all addresses in lowercase. and check incoming connections as lowercase.
I had some users run into this issue, and can't think of a reason to have case sensitive hostnames for servers, but let me know if you have a different view.