### PR TITLE
add link to related project https://github.com/haveachin/infrared

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,7 @@ docker run -it --rm \
   goreleaser/goreleaser \
   release --snapshot --rm-dist
 ```
+
+# Related Projects
+
+* https://github.com/haveachin/infrared


### PR DESCRIPTION
I don't know if you would consider linking to a project by @haveachin in roughly the same space as this? Even if you don't seem to serve exactly the same use case, it might still be of interest to other folks looking at this. (Personally I'm considering to explore perhaps using BOTH of these projects together - one single `mc-router` as front-end entry point to dispatch, and multiple N `infrared` back-end "wrapping" instances for on-demand starting of Minecraft server containers via their respective StatefulSets. FYI @edewit.)