### PR TITLE
Add possibility to use multiple names for one service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           go-version: 1.17
 
+      - name: Test
+        run: go test ./...
+
       - name: Run GoReleaser Snapshot
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To test out this example, I added these two entries to my "hosts" file:
 When running `mc-router` as a kubernetes pod and you pass the `--in-kube-cluster` command-line argument, then
 it will automatically watch for any services annotated with 
 - `mc-router.itzg.me/externalServerName` : The value of the annotation will be registered as the external hostname Minecraft clients would used to connect to the
-   routed service. The service's clusterIP and target port are used as the routed backend.
+   routed service. The service's clusterIP and target port are used as the routed backend. You can use more hostnames by splitting them with comma.
 - `mc-router.itzg.me/defaultServer` : The service's clusterIP and target port are used as the default if
   no other `externalServiceName` annotations applies.
 
@@ -129,6 +129,17 @@ metadata:
     "mc-router.itzg.me/externalServerName": "external.host.name"
 ```
 
+you can use multiple host names:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mc-forge
+  annotations:
+    "mc-router.itzg.me/externalServerName": "external.host.name,other.host.name"
+```
+
 ## Example kubernetes deployment
 
 [This example deployment](docs/k8s-example-auto.yaml) 
@@ -136,7 +147,7 @@ metadata:
 * Declares a service account with access to watch and list services
 * Declares `--in-kube-cluster` in the `mc-router` container arguments
 * Two "backend" Minecraft servers are declared each with an 
-  `"mc-router.itzg.me/externalServerName"` annotation that declares their external server name
+  `"mc-router.itzg.me/externalServerName"` annotation that declares their external server name(s)
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/itzg/mc-router/master/docs/k8s-example-auto.yaml

--- a/server/k8s.go
+++ b/server/k8s.go
@@ -68,7 +68,7 @@ func (w *k8sWatcherImpl) startWithLoadedConfig(config *rest.Config) error {
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				routableServices := extractRoutableService(obj)
+				routableServices := extractRoutableServices(obj)
 				for _, routableService := range routableServices {
 					if routableService != nil {
 						logrus.WithField("routableService", routableService).Debug("ADD")
@@ -82,7 +82,7 @@ func (w *k8sWatcherImpl) startWithLoadedConfig(config *rest.Config) error {
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				routableServices := extractRoutableService(obj)
+				routableServices := extractRoutableServices(obj)
 				for _, routableService := range routableServices {
 					if routableService != nil {
 						logrus.WithField("routableService", routableService).Debug("DELETE")
@@ -96,8 +96,8 @@ func (w *k8sWatcherImpl) startWithLoadedConfig(config *rest.Config) error {
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				oldRoutableServices := extractRoutableService(oldObj)
-				newRoutableServices := extractRoutableService(newObj)
+				oldRoutableServices := extractRoutableServices(oldObj)
+				newRoutableServices := extractRoutableServices(newObj)
 				var length int
 				if len(oldRoutableServices) > len(newRoutableServices) {
 					length = len(oldRoutableServices)
@@ -144,7 +144,7 @@ type routableService struct {
 	containerEndpoint   string
 }
 
-func extractRoutableService(obj interface{}) []*routableService {
+func extractRoutableServices(obj interface{}) []*routableService {
 	service, ok := obj.(*v1.Service)
 	if !ok {
 		return nil

--- a/server/k8s_test.go
+++ b/server/k8s_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestK8sWatcherImpl_handleAddAndUpdate(t *testing.T) {
+	type scenario struct {
+		given  string
+		expect string
+	}
+	type svcAndScenarios struct {
+		svc       string
+		scenarios []scenario
+	}
+	tests := []struct {
+		name    string
+		initial svcAndScenarios
+		update  svcAndScenarios
+	}{
+		{
+			name: "a to b",
+			initial: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "a.com"}}, "spec":{"clusterIP": "1.1.1.1"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: "1.1.1.1:25565"},
+					{given: "b.com", expect: ""},
+				},
+			},
+			update: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "b.com"}}, "spec":{"clusterIP": "1.1.1.1"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: ""},
+					{given: "b.com", expect: "1.1.1.1:25565"},
+				},
+			},
+		},
+		{
+			name: "a to a,b",
+			initial: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "a.com"}}, "spec":{"clusterIP": "1.1.1.1"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: "1.1.1.1:25565"},
+					{given: "b.com", expect: ""},
+				},
+			},
+			update: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "a.com,b.com"}}, "spec":{"clusterIP": "1.1.1.1"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: "1.1.1.1:25565"},
+					{given: "b.com", expect: "1.1.1.1:25565"},
+				},
+			},
+		},
+		{
+			name: "a,b to b",
+			initial: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "a.com,b.com"}}, "spec":{"clusterIP": "1.1.1.1"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: "1.1.1.1:25565"},
+					{given: "b.com", expect: "1.1.1.1:25565"},
+				},
+			},
+			update: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "b.com"}}, "spec":{"clusterIP": "1.1.1.1"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: ""},
+					{given: "b.com", expect: "1.1.1.1:25565"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// reset the routes
+			Routes.RegisterAll(map[string]string{})
+
+			watcher := &k8sWatcherImpl{}
+			initialSvc := v1.Service{}
+			err := json.Unmarshal([]byte(test.initial.svc), &initialSvc)
+			require.NoError(t, err)
+
+			watcher.handleAdd(&initialSvc)
+			for _, s := range test.initial.scenarios {
+				backend, _ := Routes.FindBackendForServerAddress(s.given)
+				assert.Equal(t, s.expect, backend, "initial: given=%s", s.given)
+			}
+
+			updatedSvc := v1.Service{}
+			err = json.Unmarshal([]byte(test.update.svc), &updatedSvc)
+			require.NoError(t, err)
+
+			watcher.handleUpdate(&initialSvc, &updatedSvc)
+			for _, s := range test.update.scenarios {
+				backend, _ := Routes.FindBackendForServerAddress(s.given)
+				assert.Equal(t, s.expect, backend, "update: given=%s", s.given)
+			}
+		})
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -87,6 +87,7 @@ type IRoutes interface {
 	RegisterAll(mappings map[string]string)
 	// FindBackendForServerAddress returns the host:port for the external server address, if registered.
 	// Otherwise, an empty string is returned
+	// Also returns the normalized version of the given serverAddress
 	FindBackendForServerAddress(serverAddress string) (string, string)
 	GetMappings() map[string]string
 	DeleteMapping(serverAddress string) bool


### PR DESCRIPTION
This PR adds splitting by `,` in annotation so we can have multiple names pointing one service.