### PR TITLE
misc: Disable organizing imports in Visual Studio Code (see #28)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    // https://github.com/itzg/mc-router/pull/28
+    "go.formatTool": "gofmt",
+    "[go]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": false,
+        },
+        "editor.formatOnSave": true
+    }
+}


### PR DESCRIPTION
see our discussion in #28

This is actually NOT my recommended / favourite solution to that problem, but let's see your response in #28.

Alternatively, if you don't want to change import ordering on your side, then do merge this, at least for now, as it makes it much easier for me.