### PR TITLE
Add documentation for routes config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ To test out this example, I added these two entries to my "hosts" file:
 127.0.0.1 forge.example.com
 ```
 
+# Routing Configuration
+
+The routing configuration allows routing via a config file rather than a command. 
+You need to set `-routes-config` or `ROUTES_CONFIG` env variable.
+No you can define the routing via json file. `default-server` can be `null` as well.
+
+```json
+{
+  "default-server": "vanilla:25565",
+  "mappings": {
+    "vanilla.example.com": "vanilla:25565",
+    "forge.example.com": "forge:25565"
+  }
+}
+```
+
 # Kubernetes Usage
 
 ## Using Kubernetes Service auto-discovery


### PR DESCRIPTION
I added some documentation for the routes config file, since it was missing in the readme.