### PR TITLE
Possible solution for wildcard fixing

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var tcpShieldPattern = regexp.MustCompile("///.*")
+
 func init() {
 	apiRoutes.Path("/routes").Methods("GET").
 		Headers("Accept", "application/json").
@@ -179,7 +181,7 @@ func (r *routesImpl) FindBackendForServerAddress(ctx context.Context, serverAddr
 		strings.TrimSuffix(addressParts[0], "."))
 
 	// Strip suffix of TCP Shield
-	address = regexp.MustCompile("///.*").ReplaceAllString(address, "")
+	address = tcpShieldPattern.ReplaceAllString(address, "")
 
 	if r.mappings != nil {
 		if mapping, exists := r.mappings[address]; exists {

--- a/server/routes.go
+++ b/server/routes.go
@@ -182,12 +182,10 @@ func (r *routesImpl) FindBackendForServerAddress(ctx context.Context, serverAddr
 			return mapping.backend, address, mapping.waker
 		}
 		// Search for wildcard matches
-		for currMapping := range r.mappings {
-			if strings.HasSuffix(currMapping, "*") {
-				if strings.HasPrefix(address, currMapping[:len(currMapping)-1]) {
-					mapping := r.mappings[currMapping]
-					return mapping.backend, address, mapping.waker
-				}
+		for currMapping := range r.mapping {
+			if strings.HasSuffix(currMapping, "*") && strings.HasPrefix(address, currMapping[:len(currMapping)-1]) {
+				mapping := r.mappings[currMapping]
+				return mapping.backend, address, mapping.waker
 			}
 		}
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -181,6 +181,15 @@ func (r *routesImpl) FindBackendForServerAddress(ctx context.Context, serverAddr
 		if mapping, exists := r.mappings[address]; exists {
 			return mapping.backend, address, mapping.waker
 		}
+		// Search for wildcard matches
+		for currMapping := range r.mappings {
+			if strings.HasSuffix(currMapping, "*") {
+				if strings.HasPrefix(address, currMapping[:len(currMapping)-1]) {
+					mapping := r.mappings[currMapping]
+					return mapping.backend, address, mapping.waker
+				}
+			}
+		}
 	}
 	return r.defaultRoute, address, nil
 }


### PR DESCRIPTION
First of all: I never used GO before. So see this more as a proposal than a proper implementation. Feel free to make changes.

Background of this is that services like tcp shield add more context to the domain. If I route a domain like mc.example.com I get something like 
```
mc.example.com///127.0.0.1:25565///1684918045///MGQCMBSW001TpRFxZBMq6nA/OS8y1B8S3sUc9CpAeFb7lzdvtvP+vqjjI8mMD1sQ1njiFQIwOyqxfe6HpxT+GYkOJB5n0VhDruEWMQySf8GcudKmTArMvPEEtAtQWUbO8hkSx++y
```
This is an ever changing value which has some meaning for tcp shield. So far it seems to be unique for every single connection.

At the current state tcp shield cant be used in front of mc-router since those urls are impossible to match.
Allowing to do wild card matches like `mc.example.com/* Would allow the router to accept those connections as well. 

Also the docker build fails for me, but it doesnt look like an compiler error, so I am quite unsure how to resolve it, but I also noticed that the test build also failed the last times, so it is probably not related to my changes? Therefore this change is still untested.