### PR TITLE
Prevent crash due to large memory allocation

### DIFF
--- a/mcproto/read.go
+++ b/mcproto/read.go
@@ -160,6 +160,12 @@ func ReadFrame(reader io.Reader, addr net.Addr) (*Frame, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Limit frame length to 2^21 - 1
+	if frame.Length > 2097151 {
+		return nil, errors.Errorf("frame length %d too large", frame.Length)
+	}
+
 	logrus.
 		WithField("client", addr).
 		WithField("length", frame.Length).


### PR DESCRIPTION
I was experiencing OOMKilled on my mc-router running in K8s, and found out through debug logs that I was receiving exceptionally large frame sizes:

```
time="2024-05-06T01:17:28Z" level=info msg="Got connection" client="10.42.0.1:52383"                                                                          time="2024-05-06T01:17:28Z" level=debug msg="Reading packet" client="10.42.0.1:52383"
time="2024-05-06T01:17:28Z" level=debug msg="Reading frame" client="10.42.0.1:52383"
time="2024-05-06T01:17:28Z" level=debug msg="Read frame length" client="10.42.0.1:52383" length=32426894721
```

Took a look at the code and this size of frame would certainly overallocate the buffer, causing OOM or DoS.

It should be noted the protocol does limit the number of bytes to 2^21-1: https://wiki.vg/Protocol#Packet_format

This PR limits the frame length to 2^21-1.