### PR TITLE
Update documentation - autoscaling requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,7 @@ rules:
 ```
 
 Make sure to set `StatefulSet.metadata.name` and `StatefulSet.spec.serviceName` to the same value;
-otherwise, autoscaling will not trigger (`mc-router.itzg.me/externalServerName` annotation is also required for it to work,
-however if you are not using a DNS you can specify an IP address as well `"mc-router.itzg.me/externalServerName": "1.2.3.4"`):
+otherwise, autoscaling will not trigger:
 
 ```yaml
 apiVersion: v1

--- a/README.md
+++ b/README.md
@@ -244,6 +244,29 @@ rules:
   verbs: ["watch","list","get","update"]
 ```
 
+Make sure to set `StatefulSet.metadata.name` and `StatefulSet.spec.serviceName` to the same value;
+otherwise, autoscaling will not trigger (`mc-router.itzg.me/externalServerName` annotation is also required for it to work,
+however if you are not using a DNS you can specify an IP address as well `"mc-router.itzg.me/externalServerName": "1.2.3.4"`):
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mc-forge
+spec:
+  type: ClusterIP
+  annotations:
+    "mc-router.itzg.me/defaultServer": "true"
+    "mc-router.itzg.me/externalServerName": "external.host.name"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mc-forge
+spec:
+  serviceName: mc-forge
+```
+
 ## REST API
 
 * `GET /routes` (with `Accept: application/json`)


### PR DESCRIPTION
This PR updates the documentation to raise awareness of the requirements for StatefulSet autoscaling in Kubernetes to function properly.

#311 