### PR TITLE
Upgrade to Go 1.23.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser-image.yml@main
     with:
-      go-version: "1.22.11"
+      go-version: "1.23.6"
     secrets:
       image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser-image.yml@main
     with:
-      go-version: "1.22.5"
+      go-version: "1.22.11"
     secrets:
       image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,4 @@ jobs:
   build:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.22.5"
+      go-version: "1.22.11"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,4 @@ jobs:
   build:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.22.11"
+      go-version: "1.23.6"

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/itzg/mc-router
 
 go 1.21
 
-toolchain go1.22.11
+toolchain go1.23.6
 
 require (
 	github.com/go-kit/kit v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/itzg/mc-router
 
 go 1.21
 
-toolchain go1.22.5
+toolchain go1.22.11
 
 require (
 	github.com/go-kit/kit v0.13.0


### PR DESCRIPTION
Resolve vulnerabilities reported in https://github.com/itzg/mc-router/actions/runs/13620850524/job/38070092207?pr=368

```
Vulnerability #1: GO-2025-3447
    Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec
  More info: https://pkg.go.dev/vuln/GO-2025-3447
  Standard library
    Found in: crypto/internal/nistec@go1.22.5
    Fixed in: crypto/internal/nistec@go1.22.12
    Platforms: ppc64le
    Example traces found:
Error:       #1: mcproto/read.go:257:23: mcproto.ReadByte calls io.LimitedReader.Read, which eventually calls nistec.P256Point.ScalarBaseMult
Error:       #2: mcproto/read.go:257:23: mcproto.ReadByte calls io.LimitedReader.Read, which eventually calls nistec.P256Point.ScalarMult
Error:       #3: server/connector.go:74:32: server.Connector.createListener calls ngrok.Listen, which eventually calls nistec.P256Point.SetBytes

Vulnerability #2: GO-2025-3420
    Sensitive headers incorrectly sent after cross-domain redirect in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3420
  Standard library
    Found in: net/http@go1.22.5
    Fixed in: net/http@go1.22.11
    Example traces found:
Error:       #1: cmd/mc-router/metrics.go:98:2: mc.influxMetricsBuilder.Start calls influx.Influx.WriteLoop, which eventually calls http.Client.Do

Vulnerability #3: GO-2025-3373
    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3373
  Standard library
    Found in: crypto/x509@go1.22.5
    Fixed in: crypto/x509@go1.22.11
    Example traces found:
Error:       #1: server/connector.go:74:32: server.Connector.createListener calls ngrok.Listen, which eventually calls x509.CertPool.AppendCertsFromPEM
Error:       #2: mcproto/read.go:257:23: mcproto.ReadByte calls io.LimitedReader.Read, which eventually calls x509.Certificate.Verify
Error:       #3: mcproto/read.go:257:23: mcproto.ReadByte calls io.LimitedReader.Read, which eventually calls x509.Certificate.VerifyHostname
Error:       #4: mcproto/types.go:41:21: mcproto.Packet.String calls fmt.Sprintf, which eventually calls x509.HostnameError.Error
Error:       #5: server/k8s.go:47:37: server.k8sWatcherImpl.StartInCluster calls rest.InClusterConfig, which eventually calls x509.ParseCertificate
Error:       #6: server/k8s.go:67:43: server.k8sWatcherImpl.startWithLoadedConfig calls kubernetes.NewForConfig, which eventually calls x509.ParseECPrivateKey
Error:       #7: server/k8s.go:67:43: server.k8sWatcherImpl.startWithLoadedConfig calls kubernetes.NewForConfig, which eventually calls x509.ParsePKCS1PrivateKey
Error:       #8: server/k8s.go:67:43: server.k8sWatcherImpl.startWithLoadedConfig calls kubernetes.NewForConfig, which eventually calls x509.ParsePKCS8PrivateKey

```