### PR TITLE
Do not autoscale up on status requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 WORKDIR /build
 

--- a/mcproto/types.go
+++ b/mcproto/types.go
@@ -56,6 +56,10 @@ type Handshake struct {
 	NextState       int
 }
 
+const (
+	StateStatus State = 1
+)
+
 type LegacyServerListPing struct {
 	ProtocolVersion int
 	ServerAddress   string


### PR DESCRIPTION
Fixes #387 

Looking at the Minecraft protocol documentation, I saw the [handshake request sends info about the state of following requests](https://minecraft.wiki/w/Java_Edition_protocol#Handshake). I saw this was already being parsed so I simply passed that through to the `findAndConnectToBackend` and only scale if that value is not a `status` request (for the legacy server ping, I hard-code the `NextState` to match the `status` state of the current protocol).

I tested this by building the image and loading it into a local Kubernetes cluster with two Minecraft servers behind the `mc-router`. I then launched Minecraft and confirmed that simply opening the server list did not scale up either server. I attempted to connect to `Server A` and saw the StatefulSet scale up. I then attempted to connect to `Server B` and confirmed that StatefulSet also scaled up.

I'm not super familiar with the Minecraft protocol and am unsure if there would be any negative side effects of this change. If so, I'm happy to put this behind another config flag!