### PR TITLE
Handle truncated start login frame

### DIFF
--- a/mcproto/decode.go
+++ b/mcproto/decode.go
@@ -55,12 +55,12 @@ func DecodeLoginStart(data interface{}) (*LoginStart, error) {
 
 	loginStart.Name, err = ReadString(buffer)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read username")
+		return loginStart, errors.Wrap(err, "failed to read username")
 	}
 
 	loginStart.PlayerUuid, err = ReadUuid(buffer)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read player uuid")
+		return loginStart, errors.Wrap(err, "failed to read player uuid")
 	}
 
 	return loginStart, nil

--- a/mcproto/read.go
+++ b/mcproto/read.go
@@ -1,3 +1,5 @@
+// Package mcproto provides functions to read types and decode frames declared
+// at https://minecraft.wiki/w/Java_Edition_protocol
 package mcproto
 
 import (
@@ -27,7 +29,7 @@ const MaxFrameLength = 2097151
 func ReadPacket(reader *bufio.Reader, addr net.Addr, state State) (*Packet, error) {
 	logrus.
 		WithField("client", addr).
-		Debug("Reading packet")
+		Trace("Reading packet")
 
 	if state == StateHandshaking {
 		data, err := reader.Peek(1)
@@ -158,7 +160,7 @@ func ReadUTF16BEString(reader io.Reader, symbolLen uint16) (string, error) {
 func ReadFrame(reader io.Reader, addr net.Addr) (*Frame, error) {
 	logrus.
 		WithField("client", addr).
-		Debug("Reading frame")
+		Trace("Reading frame")
 
 	var err error
 	frame := &Frame{}


### PR DESCRIPTION
In rare cases the start login frame seems to be truncated or shorter than expected. Error log was:

```
time="2025-04-25T02:08:08Z" level=error msg="Failed to read user info" clientAddr="176.65.149.246:43726" error="failed to decode login start: failed to read player uuid: EOF"
```

Also
- lowered "Got connection" log to debug
- lowered some of the reading packet/frame to trace