### PR TITLE
Feature sighup reload routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ The following shows a JSON file for routes config, where `default-server` can al
 }
 ```
 
+Sending a SIGHUP signal will cause mc-router to reload the routes config from disk.
+
 ## Auto Scale Allow/Deny List
 
 The allow/deny list configuration allows limiting which players can scale up servers when using the `-auto-scale-up` option (`AUTO_SCALE_UP` env variable) and which players can cancel an active down scaler when using the `-auto-scale-down` option (`AUTO_SCALE_DOWN` env variable). Global allow/deny lists can be configured that apply to all backend servers, but server-specific lists can be added as well. There are a few important things to note about the configuration:

--- a/cmd/mc-router/main.go
+++ b/cmd/mc-router/main.go
@@ -256,12 +256,14 @@ func main() {
 		sig := <-c
 		switch sig {
 		case syscall.SIGHUP:
-			logrus.Info("Received SIGHUP, reloading routes config...")
-			if err := server.RoutesConfig.ReloadRoutesConfig(); err != nil {
-				logrus.
-					WithError(err).
-					WithField("routesConfig", config.Routes.Config).
-					Error("Could not re-read the routes config file")
+			if config.Routes.Config != "" {
+				logrus.Info("Received SIGHUP, reloading routes config...")
+				if err := server.RoutesConfig.ReloadRoutesConfig(); err != nil {
+					logrus.
+						WithError(err).
+						WithField("routesConfig", config.Routes.Config).
+						Error("Could not re-read the routes config file")
+				}
 			}
 		case syscall.SIGINT, syscall.SIGTERM:
 			logrus.WithField("signal", sig).Info("Stopping. Waiting for connections to complete...")

--- a/cmd/mc-router/main.go
+++ b/cmd/mc-router/main.go
@@ -144,7 +144,7 @@ func main() {
 	server.DownScaler = server.NewDownScaler(ctx, downScalerEnabled, downScalerDelay)
 
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	if config.Routes.Config != "" {
 		err := server.RoutesConfig.ReadRoutesConfig(config.Routes.Config)
@@ -251,10 +251,26 @@ func main() {
 		logrus.WithError(err).Fatal("Unable to start metrics reporter")
 	}
 
-	// wait for process-stop signal
-	<-c
-	logrus.Info("Stopping. Waiting for connections to complete...")
-	signal.Stop(c)
-	connector.WaitForConnections()
-	logrus.Info("Stopped")
+	// handle signals
+	for {
+		sig := <-c
+		switch sig {
+		case syscall.SIGHUP:
+			logrus.Info("Received SIGHUP, reloading routes config...")
+			if err := server.RoutesConfig.ReloadRoutesConfig(); err != nil {
+				logrus.
+					WithError(err).
+					WithField("routesConfig", config.Routes.Config).
+					Error("Could not re-read the routes config file")
+			}
+		case syscall.SIGINT, syscall.SIGTERM:
+			logrus.WithField("signal", sig).Info("Stopping. Waiting for connections to complete...")
+			signal.Stop(c)
+			connector.WaitForConnections()
+			logrus.Info("Stopped")
+			return
+		default:
+			logrus.WithField("signal", sig).Warn("Received unexpected signal")
+		}
+	}
 }

--- a/server/routes_config.go
+++ b/server/routes_config.go
@@ -3,10 +3,11 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"time"
+
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"time"
 
 	"io/fs"
 	"os"
@@ -15,6 +16,7 @@ import (
 
 type IRoutesConfig interface {
 	ReadRoutesConfig(routesConfig string)
+	ReloadRoutesConfig()
 	AddMapping(serverAddress string, backend string)
 	DeleteMapping(serverAddress string)
 	SetDefaultRoute(backend string)
@@ -56,7 +58,7 @@ func (r *routesConfigImpl) ReadRoutesConfig(routesConfig string) error {
 	return nil
 }
 
-func (r *routesConfigImpl) reloadRoutesConfig() error {
+func (r *routesConfigImpl) ReloadRoutesConfig() error {
 	config, readErr := r.readRoutesConfigFile()
 
 	if readErr != nil {


### PR DESCRIPTION
I took a stab at adding SIGHUP handling which will cause routes to be reloaded from disk if a routes config file is being used. I made a change to routes_config.go to allow ReloadRoutesConfig() to be called. This works well to also remove old routes given that it calls the Routes.Reset() function in additional to reloading routes from disk.