### PR TITLE
feat(k8s): ExternalName service support

### DIFF
--- a/server/k8s.go
+++ b/server/k8s.go
@@ -235,6 +235,9 @@ func (w *k8sWatcherImpl) extractRoutableServices(obj interface{}) []*routableSer
 
 func (w *k8sWatcherImpl) buildDetails(service *core.Service, externalServiceName string) *routableService {
 	clusterIp := service.Spec.ClusterIP
+	if service.Spec.Type == core.ServiceTypeExternalName {
+		clusterIp = service.Spec.ExternalName
+	}
 	port := "25565"
 	for _, p := range service.Spec.Ports {
 		if p.Name == "mc-router" || p.Name == "minecraft" {

--- a/server/k8s_test.go
+++ b/server/k8s_test.go
@@ -80,7 +80,7 @@ func TestK8sWatcherImpl_handleAddThenUpdate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// DownScaler needs to be instantiated
-			DownScaler = NewDownScaler(context.Background(), false, 1 * time.Second)
+			DownScaler = NewDownScaler(context.Background(), false, 1*time.Second)
 			Routes.Reset()
 
 			watcher := &k8sWatcherImpl{}
@@ -153,7 +153,7 @@ func TestK8sWatcherImpl_handleAddThenDelete(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// DownScaler needs to be instantiated
-			DownScaler = NewDownScaler(context.Background(), false, 1 * time.Second)
+			DownScaler = NewDownScaler(context.Background(), false, 1*time.Second)
 			Routes.Reset()
 
 			watcher := &k8sWatcherImpl{}
@@ -169,6 +169,102 @@ func TestK8sWatcherImpl_handleAddThenDelete(t *testing.T) {
 
 			watcher.handleDelete(&initialSvc)
 			for _, s := range test.delete {
+				backend, _, _, _ := Routes.FindBackendForServerAddress(context.Background(), s.given)
+				assert.Equal(t, s.expect, backend, "update: given=%s", s.given)
+			}
+		})
+	}
+}
+
+func TestK8s_externalName(t *testing.T) {
+	type scenario struct {
+		given  string
+		expect string
+	}
+	type svcAndScenarios struct {
+		svc       string
+		scenarios []scenario
+	}
+	tests := []struct {
+		name    string
+		initial svcAndScenarios
+		update  svcAndScenarios
+	}{
+		{
+			name: "typeChange",
+			initial: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "a.com"}}, "spec":{"type":"ExternalName", "externalName": "mc-server.com"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: "mc-server.com:25565"},
+					{given: "b.com", expect: ""},
+				},
+			},
+			update: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "a.com"}}, "spec":{"clusterIP": "1.1.1.1"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: "1.1.1.1:25565"},
+					{given: "b.com", expect: ""},
+				},
+			},
+		},
+		{
+			name: "typeAndServerChange",
+			initial: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "a.com"}}, "spec":{"type":"ExternalName", "externalName": "mc-server.com"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: "mc-server.com:25565"},
+					{given: "b.com", expect: ""},
+				},
+			},
+			update: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "b.com"}}, "spec":{"clusterIP": "1.1.1.1"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: ""},
+					{given: "b.com", expect: "1.1.1.1:25565"},
+				},
+			},
+		},
+		{
+			name: "externalNameChange",
+			initial: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "a.com,b.com"}}, "spec":{"type":"ExternalName", "externalName": "mc-server.com"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: "mc-server.com:25565"},
+					{given: "b.com", expect: "mc-server.com:25565"},
+				},
+			},
+			update: svcAndScenarios{
+				svc: ` {"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "a.com,b.com"}}, "spec":{"type":"ExternalName", "externalName": "1.1.1.1"}}`,
+				scenarios: []scenario{
+					{given: "a.com", expect: "1.1.1.1:25565"},
+					{given: "b.com", expect: "1.1.1.1:25565"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// DownScaler needs to be instantiated
+			DownScaler = NewDownScaler(context.Background(), false, 1*time.Second)
+			Routes.Reset()
+
+			watcher := &k8sWatcherImpl{}
+			initialSvc := v1.Service{}
+			err := json.Unmarshal([]byte(test.initial.svc), &initialSvc)
+			require.NoError(t, err)
+
+			watcher.handleAdd(&initialSvc)
+			for _, s := range test.initial.scenarios {
+				backend, _, _, _ := Routes.FindBackendForServerAddress(context.Background(), s.given)
+				assert.Equal(t, s.expect, backend, "initial: given=%s", s.given)
+			}
+
+			updatedSvc := v1.Service{}
+			err = json.Unmarshal([]byte(test.update.svc), &updatedSvc)
+			require.NoError(t, err)
+
+			watcher.handleUpdate(&initialSvc, &updatedSvc)
+			for _, s := range test.update.scenarios {
 				backend, _, _, _ := Routes.FindBackendForServerAddress(context.Background(), s.given)
 				assert.Equal(t, s.expect, backend, "update: given=%s", s.given)
 			}


### PR DESCRIPTION
Enables using k8s service discovery, and as consequence allows config live reload, for minecraft servers that are external to the k8s cluster.

Example usecases:
1. there is a separate machine that runs minecraft servers that is in same LAN as k8s cluster
2, the IP of the minecraft server is blocked in the country of some players, use mc-router as jumper point hosted on an allowed IP to bypass the block