### PR TITLE
Fix "\x00FML3\x00" in server address

### DIFF
--- a/mcproto/decode.go
+++ b/mcproto/decode.go
@@ -2,6 +2,8 @@ package mcproto
 
 import (
 	"bytes"
+	"strings"
+
 	"github.com/pkg/errors"
 )
 
@@ -28,6 +30,9 @@ func DecodeHandshake(data interface{}) (*Handshake, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Forge Mod Loader adds some data after the server address. Truncate it.
+	handshake.ServerAddress, _, _ = strings.Cut(handshake.ServerAddress, string(rune(0)))
 
 	handshake.ServerPort, err = ReadUnsignedShort(buffer)
 	if err != nil {


### PR DESCRIPTION
Clients utilizing Forge Mod Loader protocol v3 include `\x00FML3\x00` at the end of the server address in the handshake packet. This shows up in logs, metrics, and webhooks. For example:

```
mc_router_server_active_player{player_name="playerName",player_uuid="00000000-0000-0000-0000-000000000000",server_address="my.server.address�FML3�"} 0
```

This PR truncates everything after the first `\0`.