### PR TITLE
builds: add back arm/v6 docker images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,10 @@ dockers_v2:
       - "itzg/{{ .ProjectName }}"
       - "ghcr.io/itzg/{{ .ProjectName }}"
     dockerfile: Dockerfile.release  
+    platforms:
+      - linux/amd64
+      - linux/arm64
+      - linux/arm/v6
     tags:
       - "{{ .Version }}"
       - "latest"


### PR DESCRIPTION
Small misunderstanding on my part regarding how dockers_v2 functions, resulted in arm/v6 images not being produced.