### PR TITLE
dev builds: Modify Dockerfile to add cache volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ FROM golang:1.25 AS builder
 WORKDIR /build
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 go build -buildvcs=false ./cmd/mc-router
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 go build -buildvcs=false ./cmd/mc-router
 
 FROM alpine AS certs
 RUN apk add -U \


### PR DESCRIPTION
Adds `--mount=type=cache` for the `go mod download` and `go build` steps.

Adds at least a 10x speedup compared to building from a fresh layer every time.