### PR TITLE
Add webhook-based auto-scaling for static routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Routes are populated from three sources that can be combined:
 
 ### Autoscaling backends
 
-Wakers/sleepers (`WakerFunc`/`SleeperFunc` in `routes.go`) are attached per route. Docker (`docker.go`) and Kubernetes (`k8s.go`) watchers build them from container/StatefulSet state. For **static** routes there is no watcher, so `server/webhook_scaler.go` provides a `WebhookScaler` that POSTs `{action,serverAddress,backend}` to a configured receiver (the scaling authority lives in a separate, independently-secured process — no Docker socket/kube creds/shell needed in the router). The scale-up response may optionally return `{"backend":"host:port"}` (`WebhookScaleResponse`, parsed leniently by `parseScaleResponseBackend`) to override the configured backend for that wake — for dynamic backends whose address changes per start, sidestepping stale DNS; an empty/non-JSON body keeps the configured backend. The global instance is the `WebhookAutoScaler` package singleton (mirroring `DownScaler`); its `routeFuncs` helper is nil-safe so callers (`RegisterAll`, the default route, the REST API handlers) can build waker/sleeper pairs whether or not it's configured. The scaler is global-only: it attaches to every static route (`--mapping`, `--default`, routes config file, and API-created routes), and the requested server address in the scale payload lets the receiver distinguish routes. There is deliberately no per-route scaler config (it could not round-trip through the API's `SaveRoutes`, which rewrites the file from the in-memory route table) and no `Scaler` interface yet (only webhook is implemented); a future exec mechanism would be a sibling type.
+Wakers/sleepers (`WakerFunc`/`SleeperFunc` in `routes.go`) are attached per route. Docker and Kubernetes watchers build them from container/StatefulSet state. **Static** routes have no watcher, so `server/webhook_scaler.go`'s `WebhookScaler` POSTs `{action,serverAddress,backend}` to an external receiver that owns the start/stop — keeping that privilege out of the router. The scaler is built in `server.go` and passed to the objects that register static routes (not a global — see Coding Conventions); `scaler.routeFuncs` is nil-receiver-safe. A scale-up reply may optionally return `{"backend":"host:port"}` to override the configured backend for that wake (dynamic addresses). It's deliberately global-only (no per-route config, since it couldn't round-trip through the API's `SaveRoutes`) and webhook-only (no `Scaler` interface yet).
 
 ### Key Dependencies
 
@@ -83,6 +83,15 @@ Wakers/sleepers (`WakerFunc`/`SleeperFunc` in `routes.go`) are attached per rout
 - **`connector.go`**: `ActiveConnections` map guarded by `sync.RWMutex`; `totalActiveConnections` counter uses `atomic.AddInt32`. Shutdown drain uses `sync.Cond` in `WaitForConnections()`.
 - **Bidirectional proxy**: two goroutines per connection (client→backend, backend→client) communicate via a buffered `chan error` (size 2) — first error triggers mutual close.
 - All goroutines respect context cancellation via `select { case <-ctx.Done() }`.
+
+### Coding Conventions
+
+The maintainer is gradually moving the codebase **away from package-level global singletons** (`Routes`, `DownScaler`, etc.). Do not introduce new globals in new code — construct the dependency once in `server.go` and pass the instance to the objects that need it (connector, API server, route registration). Existing globals are legacy, not a pattern to copy.
+
+- **Reuse shared infrastructure instead of parallel subsystems.** The webhook notifier and webhook scaler share one HTTP transport helper; only their call semantics differ (notifier = async fire-and-forget, scaler = synchronous control-flow with a typed response). Their timeouts stay separately configurable (notifier short, scaler long for slow infra).
+- **`key=value` config uses flagsfiller maps.** For headers and similar maps, declare a `map[string]string` field — go-flagsfiller parses it natively. Don't take `[]string` and hand-parse.
+- **Scope helpers to their type.** Package-level functions that operate on or return a type's data should be methods on that type (or live in a nested package), not free functions in `server/`.
+- **Prefer a single config surface.** Where an `action` field can discriminate behavior (e.g. one webhook URL for both up/down), favor that over two parallel flags, matching the notifier webhook.
 
 ### Error Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Go version: 1.26.2. Testing uses `testify` (assert/require). Tests are table-dri
 1. **Connector** (`server/connector.go`) accepts TCP connections on port 25565
 2. **mcproto** package (`mcproto/`) reads the Minecraft handshake packet to extract the target server address
 3. **Routes** (`server/routes.go`) looks up the backend address for that hostname
-4. If auto-scale is enabled and the backend is sleeping, a **waker** function starts it (Kubernetes StatefulSet replica 0→1 or Docker container start/unpause)
+4. If auto-scale is enabled and the backend is sleeping, a **waker** function starts it (Kubernetes StatefulSet replica 0→1, Docker container start/unpause, or a POST to a configured scale-up webhook for static routes)
 5. Traffic is proxied bidirectionally between client and backend
 6. On disconnect, metrics are updated, webhooks fired, and the **DownScaler** (`server/down_scaler.go`) may schedule scale-down after idle timeout
 
@@ -62,6 +62,10 @@ Routes are populated from three sources that can be combined:
 1. Static `--mapping` flags or JSON config file
 2. Kubernetes: watches Services with `mc-router.itzg.me/externalServerName` annotation
 3. Docker/Swarm: watches containers/services via the Docker Events API, filtered to lifecycle events (label `mc-router.host`)
+
+### Autoscaling backends
+
+Wakers/sleepers (`WakerFunc`/`SleeperFunc` in `routes.go`) are attached per route. Docker (`docker.go`) and Kubernetes (`k8s.go`) watchers build them from container/StatefulSet state. For **static** routes there is no watcher, so `server/webhook_scaler.go` provides a `WebhookScaler` that POSTs `{action,serverAddress,backend}` to a configured receiver (the scaling authority lives in a separate, independently-secured process — no Docker socket/kube creds/shell needed in the router). The scale-up response may optionally return `{"backend":"host:port"}` (`WebhookScaleResponse`, parsed leniently by `parseScaleResponseBackend`) to override the configured backend for that wake — for dynamic backends whose address changes per start, sidestepping stale DNS; an empty/non-JSON body keeps the configured backend. The global instance is the `WebhookAutoScaler` package singleton (mirroring `DownScaler`); its `routeFuncs` helper is nil-safe so callers (`RegisterAll`, the default route, the REST API handlers) can build waker/sleeper pairs whether or not it's configured. The scaler is global-only: it attaches to every static route (`--mapping`, `--default`, routes config file, and API-created routes), and the requested server address in the scale payload lets the receiver distinguish routes. There is deliberately no per-route scaler config (it could not round-trip through the API's `SaveRoutes`, which rewrites the file from the in-memory route table) and no `Scaler` interface yet (only webhook is implemented); a future exec mechanism would be a sibling type.
 
 ### Key Dependencies
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Some other features included:
     	Server scale down delay after there are no connections (env AUTO_SCALE_DOWN_AFTER) (default "10m")
   -auto-scale-up
     	Scale from zero on access. For Kubernetes, increases StatefulSet replicas from 0 to 1. For Docker, starts or unpauses the container when accessed (env AUTO_SCALE_UP)
+  -auto-scale-webhook-down-url string
+    	If set, a POST request is sent to this URL to scale a statically-configured backend down after idle (env AUTO_SCALE_WEBHOOK_DOWN_URL)
+  -auto-scale-webhook-headers value
+    	Zero or more 'key=value' headers added to scaler webhook requests, e.g. for authentication tokens (env AUTO_SCALE_WEBHOOK_HEADERS)
+  -auto-scale-webhook-timeout duration
+    	Timeout for each scaler webhook request (env AUTO_SCALE_WEBHOOK_TIMEOUT) (default 30s)
+  -auto-scale-webhook-up-url string
+    	If set, a POST request is sent to this URL to scale a statically-configured backend up on access (env AUTO_SCALE_WEBHOOK_UP_URL)
+  -auto-scale-webhook-wake-timeout duration
+    	Maximum time to wait for the backend to become reachable after a scale-up webhook (env AUTO_SCALE_WEBHOOK_WAKE_TIMEOUT) (default 1m0s)
   -clients-to-allow value
     	Zero or more client IP addresses or CIDRs to allow. Takes precedence over deny. (env CLIENTS_TO_ALLOW)
   -clients-to-deny value
@@ -111,6 +121,8 @@ Some other features included:
     	Output version and exit (env VERSION)
   -webhook-require-user
     	Indicates if the webhook will only be called if a user is connecting rather than just server list/ping (env WEBHOOK_REQUIRE_USER)
+  -webhook-timeout duration
+    	Timeout for each connection status notification request (env WEBHOOK_TIMEOUT) (default 30s)
   -webhook-url string
     	If set, a POST request that contains connection status notifications will be sent to this HTTP address (env WEBHOOK_URL)
 ```
@@ -226,6 +238,65 @@ configure two different Minecraft servers and a `mc-router` instance for use wit
 Refer to [this example docker-compose.yml](docs/swarm.docker-compose.yml) to see how to
 configure two different Minecraft servers and a `mc-router` instance for use with Docker Swarm service discovery.
 
+### Webhook Auto Scale
+
+For statically-configured routes (those defined via `-mapping`, `-default`, or the [routes config file](#routing-configuration)
+rather than discovered from Docker/Kubernetes), auto scaling can be driven by a webhook instead of mc-router managing the
+backend directly. This is useful when a **separate process** owns the scaling — for example a control-plane container that
+starts/stops the backend via its own API.
+
+Compared to running a local command, the webhook approach keeps the scaling privilege outside the router process: mc-router
+needs no Docker socket, no Kubernetes credentials, and no shell, so it can run as a minimal/distroless, least-privilege
+container. The scaling authority lives in a separately-secured receiver.
+
+Configure a scale-up and/or scale-down endpoint:
+
+```shell
+mc-router \
+  -default backend:25565 \
+  -auto-scale-webhook-up-url   http://scaler:8080/up \
+  -auto-scale-webhook-down-url http://scaler:8080/down \
+  -auto-scale-down-after 10m \
+  -auto-scale-webhook-headers "Authorization=Bearer <token>"
+```
+
+- On the first connection to a route, mc-router POSTs to the up URL, then waits (up to `-auto-scale-webhook-wake-timeout`,
+  default 60s) for the backend to become reachable before proxying.
+- When no clients remain connected and the idle timer elapses (`-auto-scale-down-after`), mc-router POSTs to the down URL.
+- Providing the URL is the opt-in; the separate `-auto-scale-up`/`-auto-scale-down` flags are not required for webhook scaling.
+
+The request body is JSON. `serverAddress` is the route the client requested (empty for the default route); `backend` is the
+configured `host:port`. Both come from mc-router's own configuration — a client can only select an existing route, never
+influence the outbound request:
+
+```json
+{
+  "action": "up",
+  "serverAddress": "survival.example.com",
+  "backend": "10.0.0.5:25565"
+}
+```
+
+A non-2xx response (or a transport error) is treated as a failure: a failed scale-up aborts the connection, and a failed
+scale-down is retried the next time the idle timer elapses. The asleep/loading MOTDs (`-auto-scale-asleep-motd`,
+`-auto-scale-loading-motd`) work the same as for Docker/Kubernetes.
+
+The scale-up response may **optionally** return the backend's current address as JSON, which overrides the configured
+`backend` for that wake:
+
+```json
+{ "backend": "10.0.0.5:25565" }
+```
+
+This is useful when the backend's address is dynamic — for example a container whose IP changes on every start. The
+receiver (which just started it) knows the live address and reports it, so mc-router connects there directly instead of
+re-resolving the configured name against a possibly-stale DNS cache. The body is optional and lenient: an empty body, a
+non-JSON body, or JSON without a `backend` field all leave the configured `backend` in effect. The scale-down response
+body is ignored.
+
+For a runnable local example — a small webhook receiver that starts/stops an `itzg/minecraft-server` container via Apple's
+`container` CLI — see [docs/webhook-scaler](docs/webhook-scaler/README.md).
+
 ## Routing Configuration
 
 The routing configuration allows routing via a config file rather than a command. 
@@ -243,6 +314,8 @@ The following shows a JSON file for routes config, where `default-server` can al
 ```
 
 Sending a SIGHUP signal will cause mc-router to reload the routes config from disk. The file can also be watched for changes by setting `-routes-config-watch` or the env variable `ROUTES_CONFIG_WATCH` to "true".
+
+When a global [webhook auto scaler](#webhook-auto-scale) is configured, it is attached to every route loaded from this file; the requested server address is sent in each scale request so the receiver can tell the routes apart.
 
 ## Auto Scale Allow/Deny List
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,12 @@ Some other features included:
     	Server scale down delay after there are no connections (env AUTO_SCALE_DOWN_AFTER) (default "10m")
   -auto-scale-up
     	Scale from zero on access. For Kubernetes, increases StatefulSet replicas from 0 to 1. For Docker, starts or unpauses the container when accessed (env AUTO_SCALE_UP)
-  -auto-scale-webhook-down-url string
-    	If set, a POST request is sent to this URL to scale a statically-configured backend down after idle (env AUTO_SCALE_WEBHOOK_DOWN_URL)
   -auto-scale-webhook-headers value
     	Zero or more 'key=value' headers added to scaler webhook requests, e.g. for authentication tokens (env AUTO_SCALE_WEBHOOK_HEADERS)
   -auto-scale-webhook-timeout duration
     	Timeout for each scaler webhook request (env AUTO_SCALE_WEBHOOK_TIMEOUT) (default 30s)
-  -auto-scale-webhook-up-url string
-    	If set, a POST request is sent to this URL to scale a statically-configured backend up on access (env AUTO_SCALE_WEBHOOK_UP_URL)
+  -auto-scale-webhook-url string
+    	If set, statically-configured backends are scaled up on access and down after idle by POSTing to this URL (env AUTO_SCALE_WEBHOOK_URL)
   -auto-scale-webhook-wake-timeout duration
     	Maximum time to wait for the backend to become reachable after a scale-up webhook (env AUTO_SCALE_WEBHOOK_WAKE_TIMEOUT) (default 1m0s)
   -clients-to-allow value
@@ -249,20 +247,20 @@ Compared to running a local command, the webhook approach keeps the scaling priv
 needs no Docker socket, no Kubernetes credentials, and no shell, so it can run as a minimal/distroless, least-privilege
 container. The scaling authority lives in a separately-secured receiver.
 
-Configure a scale-up and/or scale-down endpoint:
+Configure a single scaler endpoint; the request body's `action` field distinguishes scale-up from scale-down:
 
 ```shell
 mc-router \
   -default backend:25565 \
-  -auto-scale-webhook-up-url   http://scaler:8080/up \
-  -auto-scale-webhook-down-url http://scaler:8080/down \
+  -auto-scale-webhook-url http://scaler:8080/scale \
   -auto-scale-down-after 10m \
   -auto-scale-webhook-headers "Authorization=Bearer <token>"
 ```
 
-- On the first connection to a route, mc-router POSTs to the up URL, then waits (up to `-auto-scale-webhook-wake-timeout`,
-  default 60s) for the backend to become reachable before proxying.
-- When no clients remain connected and the idle timer elapses (`-auto-scale-down-after`), mc-router POSTs to the down URL.
+- On the first connection to a route, mc-router POSTs an `{"action":"up"}` payload, then waits (up to
+  `-auto-scale-webhook-wake-timeout`, default 60s) for the backend to become reachable before proxying.
+- When no clients remain connected and the idle timer elapses (`-auto-scale-down-after`), mc-router POSTs an
+  `{"action":"down"}` payload.
 - Providing the URL is the opt-in; the separate `-auto-scale-up`/`-auto-scale-down` flags are not required for webhook scaling.
 
 The request body is JSON. `serverAddress` is the route the client requested (empty for the default route); `backend` is the

--- a/docs/webhook-scaler/README.md
+++ b/docs/webhook-scaler/README.md
@@ -67,14 +67,13 @@ go run ./cmd/mc-router/ \
   -port 25565 \
   -mapping mc.localhost=mc.test:25565 \
   -auto-scale-down-after 2m \
-  -auto-scale-webhook-up-url   http://localhost:8080/up \
-  -auto-scale-webhook-down-url http://localhost:8080/down \
+  -auto-scale-webhook-url http://localhost:8080/scale \
   -auto-scale-asleep-motd  "Asleep — connect to wake me up" \
   -auto-scale-loading-motd "Starting up, hang on…"
 ```
 
 Notes:
-- Providing the webhook URLs is the opt-in — you do **not** also need
+- Providing the webhook URL is the opt-in — you do **not** also need
   `-auto-scale-up` / `-auto-scale-down` (those gate the Docker/Kubernetes paths).
 - The `mc.test:25565` backend is only a fallback label; the address mc-router
   actually dials is the live IP returned by `scaler.py` on each scale-up.

--- a/docs/webhook-scaler/README.md
+++ b/docs/webhook-scaler/README.md
@@ -1,0 +1,105 @@
+# Webhook auto-scale example (Apple `container`)
+
+A runnable local example of mc-router's [webhook auto scaling](../../README.md#webhook-auto-scale).
+
+A tiny Python webhook receiver ([`scaler.py`](scaler.py)) starts and stops an
+`itzg/minecraft-server` container running under [Apple's `container` CLI](https://github.com/apple/container).
+mc-router proxies Minecraft connections and calls the receiver to scale the
+backend up on the first login and back down after it goes idle.
+
+```
+Minecraft client ──▶ mc-router ──▶ minecraft-server (Apple `container`)
+                        │   ▲
+       POST {action,...}│   │ {"backend":"192.168.64.x:25565"}  (live IP on scale-up)
+                        ▼   │
+                    scaler.py ──▶ `container start/stop mc.test`
+```
+
+Apple `container` hands out a **new IP every time the container starts**, so there is no stable address to hardcode. The
+scaler solves this by reporting the container's current IP in its scale-up reply; mc-router uses that address for the wake
+instead of re-resolving a name (which would otherwise serve a stale, cached IP and time out). See
+[Webhook Auto Scale](../../README.md#webhook-auto-scale) for the optional-response contract.
+
+The point of doing this over a webhook (instead of mc-router managing the
+container itself) is the security boundary: mc-router needs no access to the
+`container` CLI, no socket, and no shell — only `scaler.py` does. mc-router can
+run as a minimal, least-privilege process while the scaling authority lives
+here.
+
+## Prerequisites
+
+- macOS with Apple's [`container`](https://github.com/apple/container) installed and started (`container system start`).
+- Go (to run mc-router from this repo) and Python 3 (for the receiver).
+
+## 1. Create the Minecraft container
+
+Create it once, **without** `--rm`, so it can be stopped and restarted rather
+than destroyed. Name it `mc.test` to match `scaler.py`'s `CONTAINER`:
+
+```shell
+container create --name mc.test -e EULA=TRUE itzg/minecraft-server
+```
+
+Leave it stopped — mc-router starts it on the first connection. You do **not**
+need to look up or hardcode its IP: Apple `container` assigns a fresh IP on
+every start, and `scaler.py` reports the current one back to mc-router in its
+scale-up reply (see [step 2](#2-start-the-webhook-receiver)). This also means
+you don't need the local `.test` DNS domain (`container system property set
+dns.domain test`) — mc-router connects to the reported IP directly.
+
+## 2. Start the webhook receiver
+
+```shell
+python3 docs/webhook-scaler/scaler.py
+```
+
+It listens on `:8080`, runs `container start mc.test` / `container stop mc.test`,
+and — on scale-up — replies with the container's current IP as
+`{"backend":"192.168.64.x:25565"}` so mc-router always connects to the live
+address.
+
+## 3. Run mc-router pointed at the receiver
+
+In another terminal, from the repo root:
+
+```shell
+go run ./cmd/mc-router/ \
+  -port 25565 \
+  -mapping mc.localhost=mc.test:25565 \
+  -auto-scale-down-after 2m \
+  -auto-scale-webhook-up-url   http://localhost:8080/up \
+  -auto-scale-webhook-down-url http://localhost:8080/down \
+  -auto-scale-asleep-motd  "Asleep — connect to wake me up" \
+  -auto-scale-loading-motd "Starting up, hang on…"
+```
+
+Notes:
+- Providing the webhook URLs is the opt-in — you do **not** also need
+  `-auto-scale-up` / `-auto-scale-down` (those gate the Docker/Kubernetes paths).
+- The `mc.test:25565` backend is only a fallback label; the address mc-router
+  actually dials is the live IP returned by `scaler.py` on each scale-up.
+- `mc.localhost` resolves to loopback, so the Minecraft client reaches mc-router
+  on the host; the handshake's server address (`mc.localhost`) is what the
+  receiver sees in the payload.
+
+## 4. Try it
+
+1. In the Minecraft client, add a server with address `mc.localhost`.
+2. Refresh the server list — while stopped you'll see the asleep MOTD, and pings
+   alone won't start it.
+3. Click **Join**. mc-router POSTs `up`, `scaler.py` runs `container start
+   mc.test` and replies with its IP, mc-router waits until that backend is
+   reachable (up to `-auto-scale-webhook-wake-timeout`, default 60s), then
+   connects you.
+4. Disconnect and wait `2m`. With no connections left, mc-router POSTs `down`
+   and `scaler.py` runs `container stop mc.test`.
+
+Watch the `scaler.py` terminal to see each `container start`/`stop` as it
+happens, and `container ls` to confirm the container's state.
+
+## Cleanup
+
+```shell
+container stop mc.test 2>/dev/null
+container rm mc.test
+```

--- a/docs/webhook-scaler/scaler.py
+++ b/docs/webhook-scaler/scaler.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Minimal webhook receiver for mc-router's webhook autoscaler.
+
+Starts/stops an itzg/minecraft-server container named "mc.test" under Apple's
+`container` CLI (https://github.com/apple/container) on mc-router's scale up/down
+webhooks. Apple `container` hands out a fresh IP on each start, so the scale-up
+reply reports the current IP ({"backend": "<ip>:25565"}) for mc-router to use.
+
+See docs/webhook-scaler/README.md for the full setup and response contract.
+"""
+import json
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+LISTEN_ADDR = ("0.0.0.0", 8080)
+CONTAINER = "mc.test"
+SERVER_PORT = 25565
+
+
+def run_container(*args):
+    result = subprocess.run(
+        ["container", *args],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.stderr.strip():
+        print(result.stderr.strip(), file=sys.stderr, flush=True)
+    return result.returncode == 0
+
+
+def container_ipv4(name):
+    """Return the running container's IPv4 (without the /CIDR suffix), or None."""
+    result = subprocess.run(
+        ["container", "ls", "--format", "json"], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        containers = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    for c in containers:
+        if c.get("configuration", {}).get("id") != name:
+            continue
+        for net in c.get("networks") or []:
+            addr = net.get("ipv4Address", "")
+            if addr:
+                return addr.split("/")[0]
+    return None
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        try:
+            payload = json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError:
+            self.respond(400)
+            return
+
+        action = payload.get("action")
+        print(f"webhook: action={action} server={payload.get('serverAddress')!r}", flush=True)
+
+        if action == "up":
+            ok = run_container("start", CONTAINER)
+            body = None
+            if ok:
+                ip = container_ipv4(CONTAINER)
+                if ip:
+                    body = {"backend": f"{ip}:{SERVER_PORT}"}
+            self.respond(200 if ok else 500, body)
+        elif action == "down":
+            ok = run_container("stop", CONTAINER)
+            self.respond(200 if ok else 500)
+        else:
+            self.respond(400)
+
+    def respond(self, status, body=None):
+        self.send_response(status)
+        if body is not None:
+            payload = json.dumps(body).encode()
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        else:
+            self.end_headers()
+
+    def log_message(self, *args):
+        pass  # quiet the default access log
+
+
+def main():
+    server = HTTPServer(LISTEN_ADDR, Handler)
+    print(f"mc-router webhook scaler listening on {LISTEN_ADDR[0]}:{LISTEN_ADDR[1]} (container '{CONTAINER}')", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/server/api_server.go
+++ b/server/api_server.go
@@ -11,11 +11,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func StartApiServer(apiBinding string) {
+// apiServer holds the dependencies the REST handlers need, injected at startup
+// rather than reached for as globals.
+type apiServer struct {
+	routes       IRoutes
+	configLoader *routesConfigLoader
+	scaler       *WebhookScaler
+}
+
+func StartApiServer(apiBinding string, routes IRoutes, configLoader *routesConfigLoader, scaler *WebhookScaler) {
 	logrus.WithField("binding", apiBinding).Info("Serving API requests")
 
+	api := &apiServer{routes: routes, configLoader: configLoader, scaler: scaler}
+
 	var apiRoutes = mux.NewRouter()
-	registerApiRoutes(apiRoutes)
+	api.registerApiRoutes(apiRoutes)
 
 	apiRoutes.Path("/vars").Handler(expvar.Handler())
 
@@ -27,26 +37,26 @@ func StartApiServer(apiBinding string) {
 	}()
 }
 
-func registerApiRoutes(apiRoutes *mux.Router) {
+func (a *apiServer) registerApiRoutes(apiRoutes *mux.Router) {
 	apiRoutes.Path("/routes").Methods("GET").
-		HandlerFunc(routesListHandler)
+		HandlerFunc(a.routesListHandler)
 	apiRoutes.Path("/routes").Methods("POST").
-		HandlerFunc(routesCreateHandler)
+		HandlerFunc(a.routesCreateHandler)
 	apiRoutes.Path("/defaultRoute").Methods("POST").
-		HandlerFunc(routesSetDefault)
-	apiRoutes.Path("/routes/{serverAddress}").Methods("DELETE").HandlerFunc(routesDeleteHandler)
+		HandlerFunc(a.routesSetDefault)
+	apiRoutes.Path("/routes/{serverAddress}").Methods("DELETE").HandlerFunc(a.routesDeleteHandler)
 }
 
-func routesListHandler(writer http.ResponseWriter, _ *http.Request) {
+func (a *apiServer) routesListHandler(writer http.ResponseWriter, _ *http.Request) {
 	type serverRoute = struct {
 		Backend       string `json:"backend"`
 		ScalingTarget string `json:"scalingTarget"`
 	}
 
-	mappings := Routes.GetMappings()
+	mappings := a.routes.GetMappings()
 	routes := make(map[string]serverRoute, len(mappings))
 	for k := range mappings {
-		backend, address, scalingTarget, _, _ := Routes.FindBackendForServerAddress(context.Background(), k)
+		backend, address, scalingTarget, _, _ := a.routes.FindBackendForServerAddress(context.Background(), k)
 		routes[address] = serverRoute{Backend: backend, ScalingTarget: scalingTarget}
 	}
 
@@ -64,19 +74,19 @@ func routesListHandler(writer http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-func routesDeleteHandler(writer http.ResponseWriter, request *http.Request) {
+func (a *apiServer) routesDeleteHandler(writer http.ResponseWriter, request *http.Request) {
 	serverAddress := mux.Vars(request)["serverAddress"]
 	if serverAddress != "" {
-		if Routes.DeleteMapping(serverAddress) {
+		if a.routes.DeleteMapping(serverAddress) {
 			writer.WriteHeader(http.StatusOK)
 		} else {
 			writer.WriteHeader(http.StatusNotFound)
 		}
-		RoutesConfigLoader.SaveRoutes()
+		a.configLoader.SaveRoutes()
 	}
 }
 
-func routesCreateHandler(writer http.ResponseWriter, request *http.Request) {
+func (a *apiServer) routesCreateHandler(writer http.ResponseWriter, request *http.Request) {
 	var definition = struct {
 		ServerAddress string
 		Backend       string
@@ -93,13 +103,13 @@ func routesCreateHandler(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	waker, sleeper := WebhookAutoScaler.routeFuncs(definition.ServerAddress, definition.Backend)
-	Routes.CreateMapping(definition.ServerAddress, definition.Backend, "", waker, sleeper, "", "")
-	RoutesConfigLoader.SaveRoutes()
+	waker, sleeper := a.scaler.routeFuncs(definition.ServerAddress, definition.Backend)
+	a.routes.CreateMapping(definition.ServerAddress, definition.Backend, "", waker, sleeper, "", "")
+	a.configLoader.SaveRoutes()
 	writer.WriteHeader(http.StatusCreated)
 }
 
-func routesSetDefault(writer http.ResponseWriter, request *http.Request) {
+func (a *apiServer) routesSetDefault(writer http.ResponseWriter, request *http.Request) {
 	var body = struct {
 		Backend string
 	}{}
@@ -115,8 +125,8 @@ func routesSetDefault(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	waker, sleeper := WebhookAutoScaler.routeFuncs("", body.Backend)
-	Routes.SetDefaultRoute(body.Backend, "", waker, sleeper, "", "")
-	RoutesConfigLoader.SaveRoutes()
+	waker, sleeper := a.scaler.routeFuncs("", body.Backend)
+	a.routes.SetDefaultRoute(body.Backend, "", waker, sleeper, "", "")
+	a.configLoader.SaveRoutes()
 	writer.WriteHeader(http.StatusOK)
 }

--- a/server/api_server.go
+++ b/server/api_server.go
@@ -93,7 +93,8 @@ func routesCreateHandler(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	Routes.CreateMapping(definition.ServerAddress, definition.Backend, "", nil, nil, "", "")
+	waker, sleeper := WebhookAutoScaler.routeFuncs(definition.ServerAddress, definition.Backend)
+	Routes.CreateMapping(definition.ServerAddress, definition.Backend, "", waker, sleeper, "", "")
 	RoutesConfigLoader.SaveRoutes()
 	writer.WriteHeader(http.StatusCreated)
 }
@@ -114,7 +115,8 @@ func routesSetDefault(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	Routes.SetDefaultRoute(body.Backend, "", nil, nil, "", "")
+	waker, sleeper := WebhookAutoScaler.routeFuncs("", body.Backend)
+	Routes.SetDefaultRoute(body.Backend, "", waker, sleeper, "", "")
 	RoutesConfigLoader.SaveRoutes()
 	writer.WriteHeader(http.StatusOK)
 }

--- a/server/configs.go
+++ b/server/configs.go
@@ -22,11 +22,10 @@ type AutoScale struct {
 // POSTing to an external HTTP receiver, which owns the start/stop of the
 // backend. This keeps the scaling privilege out of the router process.
 type AutoScaleWebhookConfig struct {
-	UpUrl       string        `usage:"If set, a POST request is sent to this URL to scale a statically-configured backend up on access"`
-	DownUrl     string        `usage:"If set, a POST request is sent to this URL to scale a statically-configured backend down after idle"`
-	Headers     []string      `usage:"Zero or more 'key=value' headers added to scaler webhook requests, e.g. for authentication tokens"`
-	Timeout     time.Duration `default:"30s" usage:"Timeout for each scaler webhook request"`
-	WakeTimeout time.Duration `default:"60s" usage:"Maximum time to wait for the backend to become reachable after a scale-up webhook"`
+	Url         string            `usage:"If set, statically-configured backends are scaled up on access and down after idle by POSTing to this URL"`
+	Headers     map[string]string `usage:"Zero or more 'key=value' headers added to scaler webhook requests, e.g. for authentication tokens"`
+	Timeout     time.Duration     `default:"30s" usage:"Timeout for each scaler webhook request"`
+	WakeTimeout time.Duration     `default:"60s" usage:"Maximum time to wait for the backend to become reachable after a scale-up webhook"`
 }
 
 type RoutesConfig struct {

--- a/server/configs.go
+++ b/server/configs.go
@@ -3,8 +3,9 @@ package server
 import "time"
 
 type WebhookConfig struct {
-	Url         string `usage:"If set, a POST request that contains connection status notifications will be sent to this HTTP address"`
-	RequireUser bool   `default:"false" usage:"Indicates if the webhook will only be called if a user is connecting rather than just server list/ping"`
+	Url         string        `usage:"If set, a POST request that contains connection status notifications will be sent to this HTTP address"`
+	RequireUser bool          `default:"false" usage:"Indicates if the webhook will only be called if a user is connecting rather than just server list/ping"`
+	Timeout     time.Duration `default:"30s" usage:"Timeout for each connection status notification request"`
 }
 
 type AutoScale struct {
@@ -14,6 +15,18 @@ type AutoScale struct {
 	AllowDeny   string        `usage:"Path to config for server allowlists and denylists. If a global/server entry is specified, only players allowed to connect to the server will be able to trigger a scale up when -auto-scale-up is enabled or cancel active down scalers when -auto-scale-down is enabled"`
 	AsleepMOTD  string        `usage:"MOTD to display when auto-scaled down servers are accessed; if empty, no status will be served"`
 	LoadingMOTD string        `usage:"MOTD to display while auto-scaled Docker servers are waking up; if empty, asleep status will be served"`
+	Webhook     AutoScaleWebhookConfig
+}
+
+// AutoScaleWebhookConfig enables scaling of statically-configured routes by
+// POSTing to an external HTTP receiver, which owns the start/stop of the
+// backend. This keeps the scaling privilege out of the router process.
+type AutoScaleWebhookConfig struct {
+	UpUrl       string        `usage:"If set, a POST request is sent to this URL to scale a statically-configured backend up on access"`
+	DownUrl     string        `usage:"If set, a POST request is sent to this URL to scale a statically-configured backend down after idle"`
+	Headers     []string      `usage:"Zero or more 'key=value' headers added to scaler webhook requests, e.g. for authentication tokens"`
+	Timeout     time.Duration `default:"30s" usage:"Timeout for each scaler webhook request"`
+	WakeTimeout time.Duration `default:"60s" usage:"Maximum time to wait for the backend to become reachable after a scale-up webhook"`
 }
 
 type RoutesConfig struct {

--- a/server/routes.go
+++ b/server/routes.go
@@ -75,7 +75,8 @@ func NewRoutes() IRoutes {
 
 func (r *routesImpl) RegisterAll(mappings map[string]string) {
 	for k, v := range mappings {
-		r.CreateMapping(k, v, "", nil, nil, "", "")
+		waker, sleeper := WebhookAutoScaler.routeFuncs(k, v)
+		r.CreateMapping(k, v, "", waker, sleeper, "", "")
 	}
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -47,7 +47,6 @@ type IRoutes interface {
 	RoutesHandler
 
 	Reset()
-	RegisterAll(mappings map[string]string)
 	// FindBackendForServerAddress returns the host:port for the external server address, if registered.
 	// Otherwise, an empty string is returned. Also returns the normalized version of the given serverAddress.
 	// The 3rd value returned is the scalingTarget which indicates what endpoint to scale (may differ from backend when using proxy).
@@ -73,10 +72,12 @@ func NewRoutes() IRoutes {
 	return r
 }
 
-func (r *routesImpl) RegisterAll(mappings map[string]string) {
+// registerStaticMappings registers each static mapping, attaching the scaler's
+// waker/sleeper pair. nil-safe: a nil scaler registers without autoscaling.
+func registerStaticMappings(routes RoutesHandler, scaler *WebhookScaler, mappings map[string]string) {
 	for k, v := range mappings {
-		waker, sleeper := WebhookAutoScaler.routeFuncs(k, v)
-		r.CreateMapping(k, v, "", waker, sleeper, "", "")
+		waker, sleeper := scaler.routeFuncs(k, v)
+		routes.CreateMapping(k, v, "", waker, sleeper, "", "")
 	}
 }
 

--- a/server/routes_config_loader.go
+++ b/server/routes_config_loader.go
@@ -44,7 +44,8 @@ func (r *routesConfigLoader) Load(routesConfigFileName string) error {
 	}
 
 	Routes.RegisterAll(config.Mappings)
-	Routes.SetDefaultRoute(config.DefaultServer, "", nil, nil, "", "")
+	waker, sleeper := WebhookAutoScaler.routeFuncs("", config.DefaultServer)
+	Routes.SetDefaultRoute(config.DefaultServer, "", waker, sleeper, "", "")
 	return nil
 }
 
@@ -62,7 +63,8 @@ func (r *routesConfigLoader) Reload() error {
 	logrus.WithField("routesConfig", r.fileName).Info("Re-loading routes config file")
 	Routes.Reset()
 	Routes.RegisterAll(config.Mappings)
-	Routes.SetDefaultRoute(config.DefaultServer, "", nil, nil, "", "")
+	waker, sleeper := WebhookAutoScaler.routeFuncs("", config.DefaultServer)
+	Routes.SetDefaultRoute(config.DefaultServer, "", waker, sleeper, "", "")
 
 	return nil
 }

--- a/server/routes_config_loader.go
+++ b/server/routes_config_loader.go
@@ -19,6 +19,13 @@ var RoutesConfigLoader = &routesConfigLoader{}
 
 type routesConfigLoader struct {
 	fileName string
+	scaler   *WebhookScaler
+}
+
+// UseWebhookScaler sets the scaler whose waker/sleeper pairs are attached to the
+// static routes loaded from the config file. nil disables autoscaling for them.
+func (r *routesConfigLoader) UseWebhookScaler(scaler *WebhookScaler) {
+	r.scaler = scaler
 }
 
 // RoutesConfigSchema declares the schema of the json file that can provide routes to serve
@@ -43,8 +50,8 @@ func (r *routesConfigLoader) Load(routesConfigFileName string) error {
 		return errors.Wrap(readErr, "Could not load the routes config file")
 	}
 
-	Routes.RegisterAll(config.Mappings)
-	waker, sleeper := WebhookAutoScaler.routeFuncs("", config.DefaultServer)
+	registerStaticMappings(Routes, r.scaler, config.Mappings)
+	waker, sleeper := r.scaler.routeFuncs("", config.DefaultServer)
 	Routes.SetDefaultRoute(config.DefaultServer, "", waker, sleeper, "", "")
 	return nil
 }
@@ -62,8 +69,8 @@ func (r *routesConfigLoader) Reload() error {
 
 	logrus.WithField("routesConfig", r.fileName).Info("Re-loading routes config file")
 	Routes.Reset()
-	Routes.RegisterAll(config.Mappings)
-	waker, sleeper := WebhookAutoScaler.routeFuncs("", config.DefaultServer)
+	registerStaticMappings(Routes, r.scaler, config.Mappings)
+	waker, sleeper := r.scaler.routeFuncs("", config.DefaultServer)
 	Routes.SetDefaultRoute(config.DefaultServer, "", waker, sleeper, "", "")
 
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -48,34 +48,30 @@ func NewServer(ctx context.Context, config *Config) (*Server, error) {
 
 	metricsBuilder := NewMetricsBuilder(config.MetricsBackend, &config.MetricsBackendConfig)
 
-	webhookDownConfigured := config.AutoScale.Webhook.DownUrl != ""
-	downScalerEnabled := (config.AutoScale.Down && (config.InKubeCluster || config.KubeConfig != "" || config.InDocker)) || webhookDownConfigured
+	webhookScalerConfigured := config.AutoScale.Webhook.Url != ""
+	downScalerEnabled := (config.AutoScale.Down && (config.InKubeCluster || config.KubeConfig != "" || config.InDocker)) || webhookScalerConfigured
 	downScalerDelay := config.AutoScale.DownAfter
 	// Only one instance should be created
 	DownScaler = NewDownScaler(ctx, downScalerEnabled, downScalerDelay)
 
-	// Build the global webhook scaler before any static routes are registered so
-	// they pick up its waker/sleeper. Discovery-based routes (Docker/Kubernetes)
-	// supply their own and are unaffected.
-	if config.AutoScale.Webhook.UpUrl != "" || config.AutoScale.Webhook.DownUrl != "" {
-		scaler, err := NewWebhookScaler(
-			config.AutoScale.Webhook.UpUrl,
-			config.AutoScale.Webhook.DownUrl,
+	// Build the webhook scaler and hand it to the objects that register static
+	// routes so they pick up its waker/sleeper. Discovery-based routes
+	// (Docker/Kubernetes) supply their own and are unaffected. A nil scaler
+	// (unconfigured) is fine: routeFuncs is nil-safe.
+	var webhookScaler *WebhookScaler
+	if webhookScalerConfigured {
+		webhookScaler = NewWebhookScaler(
+			config.AutoScale.Webhook.Url,
 			config.AutoScale.Webhook.Headers,
 			config.AutoScale.Webhook.Timeout,
 			config.AutoScale.Webhook.WakeTimeout,
 		)
-		if err != nil {
-			return nil, fmt.Errorf("could not create webhook scaler: %w", err)
-		}
-		WebhookAutoScaler = scaler
-		logrus.WithFields(logrus.Fields{
-			"upUrl":   config.AutoScale.Webhook.UpUrl,
-			"downUrl": config.AutoScale.Webhook.DownUrl,
-		}).Info("Using webhook autoscaler for static routes")
+		logrus.WithField("url", config.AutoScale.Webhook.Url).
+			Info("Using webhook autoscaler for static routes")
 	}
 
 	if config.Routes.Config != "" {
+		RoutesConfigLoader.UseWebhookScaler(webhookScaler)
 		err := RoutesConfigLoader.Load(config.Routes.Config)
 		if err != nil {
 			return nil, fmt.Errorf("could not load routes config file: %w", err)
@@ -89,9 +85,9 @@ func NewServer(ctx context.Context, config *Config) (*Server, error) {
 		}
 	}
 
-	Routes.RegisterAll(config.Mapping)
+	registerStaticMappings(Routes, webhookScaler, config.Mapping)
 	if config.Default != "" {
-		waker, sleeper := WebhookAutoScaler.routeFuncs("", config.Default)
+		waker, sleeper := webhookScaler.routeFuncs("", config.Default)
 		Routes.SetDefaultRoute(config.Default, "", waker, sleeper, "", "")
 	}
 
@@ -140,7 +136,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, error) {
 	}
 
 	if config.ApiBinding != "" {
-		StartApiServer(config.ApiBinding)
+		StartApiServer(config.ApiBinding, Routes, RoutesConfigLoader, webhookScaler)
 	}
 
 	routeWatchers := make([]RouteFinder, 0)

--- a/server/server.go
+++ b/server/server.go
@@ -48,10 +48,32 @@ func NewServer(ctx context.Context, config *Config) (*Server, error) {
 
 	metricsBuilder := NewMetricsBuilder(config.MetricsBackend, &config.MetricsBackendConfig)
 
-	downScalerEnabled := config.AutoScale.Down && (config.InKubeCluster || config.KubeConfig != "" || config.InDocker)
+	webhookDownConfigured := config.AutoScale.Webhook.DownUrl != ""
+	downScalerEnabled := (config.AutoScale.Down && (config.InKubeCluster || config.KubeConfig != "" || config.InDocker)) || webhookDownConfigured
 	downScalerDelay := config.AutoScale.DownAfter
 	// Only one instance should be created
 	DownScaler = NewDownScaler(ctx, downScalerEnabled, downScalerDelay)
+
+	// Build the global webhook scaler before any static routes are registered so
+	// they pick up its waker/sleeper. Discovery-based routes (Docker/Kubernetes)
+	// supply their own and are unaffected.
+	if config.AutoScale.Webhook.UpUrl != "" || config.AutoScale.Webhook.DownUrl != "" {
+		scaler, err := NewWebhookScaler(
+			config.AutoScale.Webhook.UpUrl,
+			config.AutoScale.Webhook.DownUrl,
+			config.AutoScale.Webhook.Headers,
+			config.AutoScale.Webhook.Timeout,
+			config.AutoScale.Webhook.WakeTimeout,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("could not create webhook scaler: %w", err)
+		}
+		WebhookAutoScaler = scaler
+		logrus.WithFields(logrus.Fields{
+			"upUrl":   config.AutoScale.Webhook.UpUrl,
+			"downUrl": config.AutoScale.Webhook.DownUrl,
+		}).Info("Using webhook autoscaler for static routes")
+	}
 
 	if config.Routes.Config != "" {
 		err := RoutesConfigLoader.Load(config.Routes.Config)
@@ -69,7 +91,8 @@ func NewServer(ctx context.Context, config *Config) (*Server, error) {
 
 	Routes.RegisterAll(config.Mapping)
 	if config.Default != "" {
-		Routes.SetDefaultRoute(config.Default, "", nil, nil, "", "")
+		waker, sleeper := WebhookAutoScaler.routeFuncs("", config.Default)
+		Routes.SetDefaultRoute(config.Default, "", waker, sleeper, "", "")
 	}
 
 	if config.ConnectionRateLimit < 1 {
@@ -96,7 +119,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, error) {
 			WithField("require-user", config.Webhook.RequireUser).
 			Info("Using webhook for connection status notifications")
 		connector.UseConnectionNotifier(
-			NewWebhookNotifier(config.Webhook.Url, config.Webhook.RequireUser))
+			NewWebhookNotifier(config.Webhook.Url, config.Webhook.RequireUser, config.Webhook.Timeout))
 	}
 
 	if config.Ngrok.Token != "" {

--- a/server/webhook_notifier.go
+++ b/server/webhook_notifier.go
@@ -1,14 +1,8 @@
 package server
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"github.com/sirupsen/logrus"
-	"log"
 	"net"
-	"net/http"
 	"time"
 )
 
@@ -18,7 +12,7 @@ type WebhookNotifier struct {
 	url         string
 	requireUser bool
 
-	client *http.Client
+	client *webhookClient
 }
 
 const (
@@ -43,14 +37,11 @@ type WebhookNotifierPayload struct {
 	Error           string      `json:"error,omitempty"`
 }
 
-func NewWebhookNotifier(url string, requireUser bool) *WebhookNotifier {
-
+func NewWebhookNotifier(url string, requireUser bool, timeout time.Duration) *WebhookNotifier {
 	return &WebhookNotifier{
 		url:         url,
 		requireUser: requireUser,
-		client: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		client:      newWebhookClient(timeout, nil),
 	}
 }
 
@@ -129,39 +120,5 @@ func (w *WebhookNotifier) NotifyDisconnected(ctx context.Context, clientAddr net
 }
 
 func (w *WebhookNotifier) send(ctx context.Context, payload *WebhookNotifierPayload) error {
-	jsonPayload, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to marshal webhook payload: %v", err)
-	}
-
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		w.url,
-		bytes.NewBuffer(jsonPayload),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create webhook request: %v", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	go func() {
-		resp, err := w.client.Do(req)
-		if err != nil {
-			// Handle error
-			log.Printf("Failed to send webhook notification: %v", err)
-			return
-		}
-		_ = resp.Body.Close()
-
-		if resp.StatusCode >= 400 {
-			logrus.
-				WithField("status", resp.StatusCode).
-				Warn("webhook receiver responded with an error")
-		}
-
-	}()
-
-	return nil
+	return w.client.postAsync(ctx, w.url, payload)
 }

--- a/server/webhook_scaler.go
+++ b/server/webhook_scaler.go
@@ -1,0 +1,194 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	scaleActionUp   = "up"
+	scaleActionDown = "down"
+)
+
+// WebhookAutoScaler is the global scaler applied to every static route
+// (--mapping, --default, routes config file, and API-created routes). nil
+// disables scaler-based autoscaling for static routes.
+var WebhookAutoScaler *WebhookScaler
+
+// WebhookScalePayload is the JSON body POSTed to the scaler webhook receiver.
+type WebhookScalePayload struct {
+	Action        string `json:"action"`
+	ServerAddress string `json:"serverAddress"`
+	Backend       string `json:"backend"`
+}
+
+// WebhookScaleResponse is the optional JSON body a receiver may return from a
+// scale-up call to override the configured backend for this wake — useful when
+// the backend's address is dynamic (e.g. a container IP that changes on every
+// start). An empty/absent body keeps the configured backend.
+type WebhookScaleResponse struct {
+	Backend string `json:"backend"`
+}
+
+// maxScaleResponseBody caps how much of the webhook response we read; we don't
+// expect a large body here, just a small JSON backend override.
+const maxScaleResponseBody = 4 << 10
+
+// WebhookScaler scales statically-configured backends by POSTing to an external
+// HTTP receiver, which owns the privilege to start/stop the backend.
+type WebhookScaler struct {
+	upURL       string
+	downURL     string
+	wakeTimeout time.Duration
+	client      *webhookClient
+}
+
+// NewWebhookScaler builds a WebhookScaler. An empty upURL/downURL disables the
+// corresponding waker/sleeper.
+func NewWebhookScaler(upURL string, downURL string, headers []string, requestTimeout time.Duration, wakeTimeout time.Duration) (*WebhookScaler, error) {
+	parsedHeaders, err := parseScalerHeaders(headers)
+	if err != nil {
+		return nil, err
+	}
+	return &WebhookScaler{
+		upURL:       upURL,
+		downURL:     downURL,
+		wakeTimeout: wakeTimeout,
+		client:      newWebhookClient(requestTimeout, parsedHeaders),
+	}, nil
+}
+
+func parseScalerHeaders(headers []string) (map[string]string, error) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	parsed := make(map[string]string, len(headers))
+	for _, h := range headers {
+		key, value, found := strings.Cut(h, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid scaler header %q, expected key=value", h)
+		}
+		parsed[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return parsed, nil
+}
+
+// routeFuncs returns the waker/sleeper pair for a static route. It is nil-safe
+// so callers can invoke it on an unconfigured (nil) scaler.
+func (s *WebhookScaler) routeFuncs(serverAddress string, backend string) (WakerFunc, SleeperFunc) {
+	if s == nil {
+		return nil, nil
+	}
+	return s.makeWakerFunc(serverAddress, backend), s.makeSleeperFunc(serverAddress, backend)
+}
+
+func (s *WebhookScaler) makeWakerFunc(serverAddress string, backend string) WakerFunc {
+	if s.upURL == "" {
+		return nil
+	}
+	return func(ctx context.Context) (string, error) {
+		override, err := s.send(ctx, scaleActionUp, serverAddress, backend)
+		if err != nil {
+			return "", fmt.Errorf("scale-up webhook failed: %w", err)
+		}
+		effectiveBackend := backend
+		if override != "" {
+			effectiveBackend = override
+			logrus.WithFields(logrus.Fields{
+				"serverAddress":     serverAddress,
+				"configuredBackend": backend,
+				"override":          override,
+			}).Debug("Using backend address from scale-up response")
+		}
+		if err := waitForBackendReachable(ctx, effectiveBackend, s.wakeTimeout); err != nil {
+			return effectiveBackend, err
+		}
+		return effectiveBackend, nil
+	}
+}
+
+func (s *WebhookScaler) makeSleeperFunc(serverAddress string, backend string) SleeperFunc {
+	if s.downURL == "" {
+		return nil
+	}
+	return func(ctx context.Context) error {
+		if _, err := s.send(ctx, scaleActionDown, serverAddress, backend); err != nil {
+			return fmt.Errorf("scale-down webhook failed: %w", err)
+		}
+		return nil
+	}
+}
+
+// send POSTs the scale request and returns an optional backend address parsed
+// from the response body (empty when the receiver returns none).
+func (s *WebhookScaler) send(ctx context.Context, action string, serverAddress string, backend string) (string, error) {
+	url := s.upURL
+	if action == scaleActionDown {
+		url = s.downURL
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"action":        action,
+		"serverAddress": serverAddress,
+		"backend":       backend,
+	}).Info("Calling scaler webhook")
+
+	resp, err := s.client.postSync(ctx, url, &WebhookScalePayload{
+		Action:        action,
+		ServerAddress: serverAddress,
+		Backend:       backend,
+	})
+	if err != nil {
+		return "", err
+	}
+	//goland:noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
+
+	return parseScaleResponseBackend(resp.Body), nil
+}
+
+// parseScaleResponseBackend extracts an optional backend address from a scaler
+// response body. It is lenient: an empty body, a non-JSON body, or JSON without
+// a "backend" field all yield an empty string, so receivers that return nothing
+// (or a plain "OK") keep working unchanged.
+func parseScaleResponseBackend(body io.Reader) string {
+	data, err := io.ReadAll(io.LimitReader(body, maxScaleResponseBody))
+	if err != nil || len(bytes.TrimSpace(data)) == 0 {
+		return ""
+	}
+	var parsed WebhookScaleResponse
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		logrus.WithError(err).Debug("Ignoring unparseable scaler response body")
+		return ""
+	}
+	return strings.TrimSpace(parsed.Backend)
+}
+
+// waitForBackendReachable blocks until a TCP connection to endpoint succeeds,
+// the context is cancelled, or timeout elapses.
+func waitForBackendReachable(ctx context.Context, endpoint string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := net.DialTimeout("tcp", endpoint, 1*time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for backend to become reachable at %s", endpoint)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}

--- a/server/webhook_scaler.go
+++ b/server/webhook_scaler.go
@@ -18,11 +18,6 @@ const (
 	scaleActionDown = "down"
 )
 
-// WebhookAutoScaler is the global scaler applied to every static route
-// (--mapping, --default, routes config file, and API-created routes). nil
-// disables scaler-based autoscaling for static routes.
-var WebhookAutoScaler *WebhookScaler
-
 // WebhookScalePayload is the JSON body POSTed to the scaler webhook receiver.
 type WebhookScalePayload struct {
 	Action        string `json:"action"`
@@ -43,42 +38,23 @@ type WebhookScaleResponse struct {
 const maxScaleResponseBody = 4 << 10
 
 // WebhookScaler scales statically-configured backends by POSTing to an external
-// HTTP receiver, which owns the privilege to start/stop the backend.
+// HTTP receiver, which owns the privilege to start/stop the backend. A single
+// URL handles both directions; the payload's action field distinguishes scale
+// up from scale down.
 type WebhookScaler struct {
-	upURL       string
-	downURL     string
+	url         string
 	wakeTimeout time.Duration
 	client      *webhookClient
 }
 
-// NewWebhookScaler builds a WebhookScaler. An empty upURL/downURL disables the
-// corresponding waker/sleeper.
-func NewWebhookScaler(upURL string, downURL string, headers []string, requestTimeout time.Duration, wakeTimeout time.Duration) (*WebhookScaler, error) {
-	parsedHeaders, err := parseScalerHeaders(headers)
-	if err != nil {
-		return nil, err
-	}
+// NewWebhookScaler builds a WebhookScaler. An empty url disables the
+// waker/sleeper.
+func NewWebhookScaler(url string, headers map[string]string, requestTimeout time.Duration, wakeTimeout time.Duration) *WebhookScaler {
 	return &WebhookScaler{
-		upURL:       upURL,
-		downURL:     downURL,
+		url:         url,
 		wakeTimeout: wakeTimeout,
-		client:      newWebhookClient(requestTimeout, parsedHeaders),
-	}, nil
-}
-
-func parseScalerHeaders(headers []string) (map[string]string, error) {
-	if len(headers) == 0 {
-		return nil, nil
+		client:      newWebhookClient(requestTimeout, headers),
 	}
-	parsed := make(map[string]string, len(headers))
-	for _, h := range headers {
-		key, value, found := strings.Cut(h, "=")
-		if !found {
-			return nil, fmt.Errorf("invalid scaler header %q, expected key=value", h)
-		}
-		parsed[strings.TrimSpace(key)] = strings.TrimSpace(value)
-	}
-	return parsed, nil
 }
 
 // routeFuncs returns the waker/sleeper pair for a static route. It is nil-safe
@@ -91,7 +67,7 @@ func (s *WebhookScaler) routeFuncs(serverAddress string, backend string) (WakerF
 }
 
 func (s *WebhookScaler) makeWakerFunc(serverAddress string, backend string) WakerFunc {
-	if s.upURL == "" {
+	if s.url == "" {
 		return nil
 	}
 	return func(ctx context.Context) (string, error) {
@@ -108,7 +84,7 @@ func (s *WebhookScaler) makeWakerFunc(serverAddress string, backend string) Wake
 				"override":          override,
 			}).Debug("Using backend address from scale-up response")
 		}
-		if err := waitForBackendReachable(ctx, effectiveBackend, s.wakeTimeout); err != nil {
+		if err := s.waitForBackendReachable(ctx, effectiveBackend, s.wakeTimeout); err != nil {
 			return effectiveBackend, err
 		}
 		return effectiveBackend, nil
@@ -116,7 +92,7 @@ func (s *WebhookScaler) makeWakerFunc(serverAddress string, backend string) Wake
 }
 
 func (s *WebhookScaler) makeSleeperFunc(serverAddress string, backend string) SleeperFunc {
-	if s.downURL == "" {
+	if s.url == "" {
 		return nil
 	}
 	return func(ctx context.Context) error {
@@ -130,18 +106,13 @@ func (s *WebhookScaler) makeSleeperFunc(serverAddress string, backend string) Sl
 // send POSTs the scale request and returns an optional backend address parsed
 // from the response body (empty when the receiver returns none).
 func (s *WebhookScaler) send(ctx context.Context, action string, serverAddress string, backend string) (string, error) {
-	url := s.upURL
-	if action == scaleActionDown {
-		url = s.downURL
-	}
-
 	logrus.WithFields(logrus.Fields{
 		"action":        action,
 		"serverAddress": serverAddress,
 		"backend":       backend,
 	}).Info("Calling scaler webhook")
 
-	resp, err := s.client.postSync(ctx, url, &WebhookScalePayload{
+	resp, err := s.client.postSync(ctx, s.url, &WebhookScalePayload{
 		Action:        action,
 		ServerAddress: serverAddress,
 		Backend:       backend,
@@ -152,14 +123,14 @@ func (s *WebhookScaler) send(ctx context.Context, action string, serverAddress s
 	//goland:noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 
-	return parseScaleResponseBackend(resp.Body), nil
+	return s.parseScaleResponseBackend(resp.Body), nil
 }
 
 // parseScaleResponseBackend extracts an optional backend address from a scaler
 // response body. It is lenient: an empty body, a non-JSON body, or JSON without
 // a "backend" field all yield an empty string, so receivers that return nothing
 // (or a plain "OK") keep working unchanged.
-func parseScaleResponseBackend(body io.Reader) string {
+func (s *WebhookScaler) parseScaleResponseBackend(body io.Reader) string {
 	data, err := io.ReadAll(io.LimitReader(body, maxScaleResponseBody))
 	if err != nil || len(bytes.TrimSpace(data)) == 0 {
 		return ""
@@ -174,7 +145,7 @@ func parseScaleResponseBackend(body io.Reader) string {
 
 // waitForBackendReachable blocks until a TCP connection to endpoint succeeds,
 // the context is cancelled, or timeout elapses.
-func waitForBackendReachable(ctx context.Context, endpoint string, timeout time.Duration) error {
+func (s *WebhookScaler) waitForBackendReachable(ctx context.Context, endpoint string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {
 		conn, err := net.DialTimeout("tcp", endpoint, 1*time.Second)

--- a/server/webhook_scaler_test.go
+++ b/server/webhook_scaler_test.go
@@ -35,8 +35,7 @@ func TestWebhookScaler_Waker(t *testing.T) {
 	}))
 	defer server.Close()
 
-	scaler, err := NewWebhookScaler(server.URL, "", []string{"Authorization=Bearer secret"}, 0, 5*time.Second)
-	require.NoError(t, err)
+	scaler := NewWebhookScaler(server.URL, map[string]string{"Authorization": "Bearer secret"}, 0, 5*time.Second)
 
 	waker := scaler.makeWakerFunc("mc.example.com", backend.Addr().String())
 	require.NotNil(t, waker)
@@ -65,8 +64,7 @@ func TestWebhookScaler_WakerUsesResponseBackend(t *testing.T) {
 	}))
 	defer server.Close()
 
-	scaler, err := NewWebhookScaler(server.URL, "", nil, 0, 5*time.Second)
-	require.NoError(t, err)
+	scaler := NewWebhookScaler(server.URL, nil, 0, 5*time.Second)
 
 	// Configured backend is a dead address; the response override must win.
 	waker := scaler.makeWakerFunc("mc.example.com", "10.255.255.1:25565")
@@ -90,8 +88,7 @@ func TestWebhookScaler_WakerFallsBackWhenResponseEmpty(t *testing.T) {
 	}))
 	defer server.Close()
 
-	scaler, err := NewWebhookScaler(server.URL, "", nil, 0, 5*time.Second)
-	require.NoError(t, err)
+	scaler := NewWebhookScaler(server.URL, nil, 0, 5*time.Second)
 
 	waker := scaler.makeWakerFunc("mc.example.com", backend.Addr().String())
 	require.NotNil(t, waker)
@@ -112,7 +109,7 @@ func TestParseScaleResponseBackend(t *testing.T) {
 		`OK`:                              "",
 	}
 	for body, want := range cases {
-		assert.Equalf(t, want, parseScaleResponseBackend(strings.NewReader(body)), "body=%q", body)
+		assert.Equalf(t, want, (&WebhookScaler{}).parseScaleResponseBackend(strings.NewReader(body)), "body=%q", body)
 	}
 }
 
@@ -128,8 +125,7 @@ func TestWebhookScaler_Sleeper(t *testing.T) {
 	}))
 	defer server.Close()
 
-	scaler, err := NewWebhookScaler("", server.URL, nil, 0, 0)
-	require.NoError(t, err)
+	scaler := NewWebhookScaler(server.URL, nil, 0, 0)
 
 	sleeper := scaler.makeSleeperFunc("mc.example.com", "10.0.0.5:25565")
 	require.NotNil(t, sleeper)
@@ -143,8 +139,7 @@ func TestWebhookScaler_Sleeper(t *testing.T) {
 }
 
 func TestWebhookScaler_NilFuncsWhenURLUnset(t *testing.T) {
-	scaler, err := NewWebhookScaler("", "", nil, 0, 0)
-	require.NoError(t, err)
+	scaler := NewWebhookScaler("", nil, 0, 0)
 
 	assert.Nil(t, scaler.makeWakerFunc("mc.example.com", "10.0.0.5:25565"))
 	assert.Nil(t, scaler.makeSleeperFunc("mc.example.com", "10.0.0.5:25565"))
@@ -156,16 +151,10 @@ func TestWebhookScaler_ErrorOnNon2xx(t *testing.T) {
 	}))
 	defer server.Close()
 
-	scaler, err := NewWebhookScaler("", server.URL, nil, 0, 0)
-	require.NoError(t, err)
+	scaler := NewWebhookScaler(server.URL, nil, 0, 0)
 
 	sleeper := scaler.makeSleeperFunc("mc.example.com", "10.0.0.5:25565")
-	err = sleeper(context.Background())
-	require.Error(t, err)
-}
-
-func TestWebhookScaler_InvalidHeader(t *testing.T) {
-	_, err := NewWebhookScaler("http://example", "", []string{"no-equals-sign"}, 0, 0)
+	err := sleeper(context.Background())
 	require.Error(t, err)
 }
 

--- a/server/webhook_scaler_test.go
+++ b/server/webhook_scaler_test.go
@@ -1,0 +1,177 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookScaler_Waker(t *testing.T) {
+	// A backend the waker can reach immediately so the reachability wait passes.
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer backend.Close()
+
+	var mu sync.Mutex
+	var gotPayload WebhookScalePayload
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		gotAuth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotPayload)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	scaler, err := NewWebhookScaler(server.URL, "", []string{"Authorization=Bearer secret"}, 0, 5*time.Second)
+	require.NoError(t, err)
+
+	waker := scaler.makeWakerFunc("mc.example.com", backend.Addr().String())
+	require.NotNil(t, waker)
+
+	addr, err := waker(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, backend.Addr().String(), addr)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, scaleActionUp, gotPayload.Action)
+	assert.Equal(t, "mc.example.com", gotPayload.ServerAddress)
+	assert.Equal(t, backend.Addr().String(), gotPayload.Backend)
+	assert.Equal(t, "Bearer secret", gotAuth)
+}
+
+func TestWebhookScaler_WakerUsesResponseBackend(t *testing.T) {
+	// The "live" backend the receiver reports; differs from the configured one.
+	liveBackend, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer liveBackend.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(WebhookScaleResponse{Backend: liveBackend.Addr().String()})
+	}))
+	defer server.Close()
+
+	scaler, err := NewWebhookScaler(server.URL, "", nil, 0, 5*time.Second)
+	require.NoError(t, err)
+
+	// Configured backend is a dead address; the response override must win.
+	waker := scaler.makeWakerFunc("mc.example.com", "10.255.255.1:25565")
+	require.NotNil(t, waker)
+
+	addr, err := waker(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, liveBackend.Addr().String(), addr)
+}
+
+func TestWebhookScaler_WakerFallsBackWhenResponseEmpty(t *testing.T) {
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer backend.Close()
+
+	// Receiver returns a non-JSON body; mc-router must ignore it and keep the
+	// configured backend.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer server.Close()
+
+	scaler, err := NewWebhookScaler(server.URL, "", nil, 0, 5*time.Second)
+	require.NoError(t, err)
+
+	waker := scaler.makeWakerFunc("mc.example.com", backend.Addr().String())
+	require.NotNil(t, waker)
+
+	addr, err := waker(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, backend.Addr().String(), addr)
+}
+
+func TestParseScaleResponseBackend(t *testing.T) {
+	cases := map[string]string{
+		`{"backend":"10.0.0.5:25565"}`:    "10.0.0.5:25565",
+		`{"backend":"  10.0.0.5:25565 "}`: "10.0.0.5:25565",
+		`{"backend":""}`:                  "",
+		`{}`:                              "",
+		``:                                "",
+		`not json`:                        "",
+		`OK`:                              "",
+	}
+	for body, want := range cases {
+		assert.Equalf(t, want, parseScaleResponseBackend(strings.NewReader(body)), "body=%q", body)
+	}
+}
+
+func TestWebhookScaler_Sleeper(t *testing.T) {
+	var mu sync.Mutex
+	var gotPayload WebhookScalePayload
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotPayload)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	scaler, err := NewWebhookScaler("", server.URL, nil, 0, 0)
+	require.NoError(t, err)
+
+	sleeper := scaler.makeSleeperFunc("mc.example.com", "10.0.0.5:25565")
+	require.NotNil(t, sleeper)
+
+	require.NoError(t, sleeper(context.Background()))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, scaleActionDown, gotPayload.Action)
+	assert.Equal(t, "10.0.0.5:25565", gotPayload.Backend)
+}
+
+func TestWebhookScaler_NilFuncsWhenURLUnset(t *testing.T) {
+	scaler, err := NewWebhookScaler("", "", nil, 0, 0)
+	require.NoError(t, err)
+
+	assert.Nil(t, scaler.makeWakerFunc("mc.example.com", "10.0.0.5:25565"))
+	assert.Nil(t, scaler.makeSleeperFunc("mc.example.com", "10.0.0.5:25565"))
+}
+
+func TestWebhookScaler_ErrorOnNon2xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	scaler, err := NewWebhookScaler("", server.URL, nil, 0, 0)
+	require.NoError(t, err)
+
+	sleeper := scaler.makeSleeperFunc("mc.example.com", "10.0.0.5:25565")
+	err = sleeper(context.Background())
+	require.Error(t, err)
+}
+
+func TestWebhookScaler_InvalidHeader(t *testing.T) {
+	_, err := NewWebhookScaler("http://example", "", []string{"no-equals-sign"}, 0, 0)
+	require.Error(t, err)
+}
+
+func TestWebhookScaler_RouteFuncsNilSafe(t *testing.T) {
+	var scaler *WebhookScaler // unconfigured
+	waker, sleeper := scaler.routeFuncs("mc.example.com", "10.0.0.5:25565")
+	assert.Nil(t, waker)
+	assert.Nil(t, sleeper)
+}

--- a/server/webhook_transport.go
+++ b/server/webhook_transport.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// webhookClient is the shared HTTP transport for the two webhook subsystems,
+// owning the http.Client, static headers, and the marshal→POST plumbing. The
+// notifier fires and forgets via postAsync; the scaler drives control flow via
+// postSync and reads the typed response body itself.
+type webhookClient struct {
+	client  *http.Client
+	headers map[string]string
+}
+
+func newWebhookClient(timeout time.Duration, headers map[string]string) *webhookClient {
+	return &webhookClient{
+		client:  &http.Client{Timeout: timeout},
+		headers: headers,
+	}
+}
+
+func (w *webhookClient) newRequest(ctx context.Context, url string, payload any) (*http.Request, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal webhook payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range w.headers {
+		req.Header.Set(k, v)
+	}
+	return req, nil
+}
+
+// postAsync sends in the background; a transport error or >=400 is logged, not returned.
+func (w *webhookClient) postAsync(ctx context.Context, url string, payload any) error {
+	req, err := w.newRequest(ctx, url, payload)
+	if err != nil {
+		return err
+	}
+	go func() {
+		resp, err := w.client.Do(req)
+		if err != nil {
+			logrus.WithError(err).Warn("Failed to send webhook notification")
+			return
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			logrus.WithField("status", resp.StatusCode).Warn("webhook receiver responded with an error")
+		}
+	}()
+	return nil
+}
+
+// postSync blocks for the response, mapping >=400 to an error. On nil error the caller closes resp.Body.
+func (w *webhookClient) postSync(ctx context.Context, url string, payload any) (*http.Response, error) {
+	req, err := w.newRequest(ctx, url, payload)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		//goland:noinspection GoUnhandledErrorResult
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("webhook responded with status %d", resp.StatusCode)
+	}
+	return resp, nil
+}


### PR DESCRIPTION
**Why / my requirements:**
1. Scale backends from a separate control process (its own API), not Docker/k8s discovery.
2. Keep mc-router itself minimal & least-privilege — no Docker socket, no kube creds, no shell (distroless-friendly).
3. Need scale-to-zero for static routes, with the scaling decision delegated out of the router.

**What**: First connection → POST scale-up URL; after idle → scale-down URL. An external receiver does the start/stop.

**Design**:  static routes get the global webhook scaler attached at creation — across --mapping, --default, config file, and the REST API, so every static route autoscales the same way.

**My Choices/insights:**

- Webhook, not exec — keeps the scaling privilege (and the shell) out of a network-facing proxy.
- Client can't shape the call: serverAddress/backend come only from config.
- Dynamic backends: scale-up response may return {"backend":"host:port"} to override the address for that wake (e.g. fresh container IP); empty body keeps the configured one. (Kinda required by my example which i put in the docs)
- Global-only by design

**Tests/example**: server/webhook_scaler_test.go, docs/webhook-scaler/ runnable receiver driving itzg/minecraft-server via Apple's container.

<img width="1512" height="893" alt="image" src="https://github.com/user-attachments/assets/de2b413b-a2ec-442d-a745-ad0ad6784218" />

> Auto-scaling via mc-router. Using Apple's container cli.