### PR TITLE
fix: bound backend dial with a timeout so asleep MOTD is served promptly

### DIFF
--- a/server/connector.go
+++ b/server/connector.go
@@ -23,6 +23,14 @@ import (
 
 const (
 	handshakeTimeout = 5 * time.Second
+	// backendDialTimeout bounds how long we wait to establish the TCP
+	// connection to a backend. Without it, dialing a Service whose backing
+	// StatefulSet is scaled to 0 (no endpoints) can hang on the OS SYN-retry
+	// timeout (~30s) — long enough that a client's server-list ping gives up
+	// before the auto-scale asleep MOTD is served from the dial-failure
+	// fallback below. A healthy backend accepts the TCP connection almost
+	// instantly, so this bound only trips on unreachable/asleep backends.
+	backendDialTimeout = 2 * time.Second
 )
 
 var noDeadline time.Time
@@ -647,7 +655,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 		Info("Connecting to backend")
 
 	//goland:noinspection GoResourceLeak ownership transferred to pumpConnections and closed with return statements below
-	backendConn, err := net.Dial("tcp", backendHostPort)
+	backendConn, err := net.DialTimeout("tcp", backendHostPort, backendDialTimeout)
 	if err != nil {
 		logrus.
 			WithError(err).


### PR DESCRIPTION
## Problem

With `--auto-scale-up`, when a backend's StatefulSet is scaled to 0 its ClusterIP Service has no endpoints. `net.Dial("tcp", backendHostPort)` on that address hangs on the OS SYN-retry timeout (~30s) instead of failing fast.

The auto-scale **asleep MOTD** is only served from the dial-failure fallback in `findAndConnectBackend`. Because the dial hangs ~30s, a client's server-list ping usually gives up before the fallback runs — so the asleep MOTD "shows only sometimes".

## Fix

Bound the backend dial with `net.DialTimeout` (2s). A healthy backend accepts the TCP connection almost instantly, so this only trips on unreachable/asleep backends — letting the existing status fallback serve the asleep MOTD promptly.

## Evidence

Verified on a live Kubernetes cluster: asleep MOTD went from ~30s (usually a client timeout, MOTD never shown) to ~2s.

## Note

The 2s bound is a const (`backendDialTimeout`) — happy to make it a flag if you'd prefer that over a fixed value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)