### PR TITLE
Fix Docker IPv6 route discovery for IPAM networks

### DIFF
--- a/examples/docker-discovery-ipv6/compose.yml
+++ b/examples/docker-discovery-ipv6/compose.yml
@@ -1,0 +1,28 @@
+services:
+  mc:
+    image: itzg/minecraft-server
+    environment:
+      EULA: "TRUE"
+      TYPE: PAPER
+      VERSION: 1.20.1
+      PREFER_IPV6: true
+    labels:
+      mc-router.host: "localhost"
+    networks:
+      - only-ipv6
+  mc-router:
+    image: itzg/mc-router
+    environment:
+      IN_DOCKER: true
+    networks:
+      - only-ipv6
+    ports:
+      - "25565:25565"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+networks:
+  only-ipv6:
+    driver: bridge
+    enable_ipv6: true
+    # https://docs.docker.com/reference/compose-file/networks/#enable_ipv4
+    enable_ipv4: false

--- a/server/docker.go
+++ b/server/docker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/sirupsen/logrus"
 )
@@ -267,7 +268,7 @@ func (w *dockerWatcherImpl) containersForID(ctx context.Context, containerID str
 	}
 	endpoint := ""
 	if !data.notRunning {
-		endpoint = fmt.Sprintf("%s:%d", data.ip, data.port)
+		endpoint = dockerBackendEndpoint(data.ip, data.port)
 	}
 	var result []*routableContainer
 	for _, host := range data.hosts {
@@ -483,7 +484,7 @@ func (w *dockerWatcherImpl) listContainers(ctx context.Context) ([]*routableCont
 
 		endpoint := ""
 		if !data.notRunning {
-			endpoint = fmt.Sprintf("%s:%d", data.ip, data.port)
+			endpoint = dockerBackendEndpoint(data.ip, data.port)
 		}
 		logrus.WithField("backendEndpoint", endpoint).
 			WithField("containerID", container.ID).
@@ -527,6 +528,20 @@ type parsedDockerContainerData struct {
 	autoScaleAsleepMOTD  string
 	autoScaleLoadingMOTD string
 	notRunning           bool
+}
+
+func dockerEndpointIP(endpoint *network.EndpointSettings) string {
+	if endpoint == nil {
+		return ""
+	}
+	if endpoint.IPAddress != "" {
+		return endpoint.IPAddress
+	}
+	return endpoint.GlobalIPv6Address
+}
+
+func dockerBackendEndpoint(ip string, port uint64) string {
+	return net.JoinHostPort(ip, strconv.FormatUint(port, 10))
 }
 
 func (w *dockerWatcherImpl) parseContainerData(container *container.InspectResponse) (data parsedDockerContainerData, ok bool) {
@@ -629,17 +644,17 @@ func (w *dockerWatcherImpl) parseContainerData(container *container.InspectRespo
 		// specified network
 		for name, endpoint := range container.NetworkSettings.Networks {
 			if name == endpoint.NetworkID {
-				data.ip = endpoint.IPAddress
+				data.ip = dockerEndpointIP(endpoint)
 			}
 
 			if name == *data.network {
-				data.ip = endpoint.IPAddress
+				data.ip = dockerEndpointIP(endpoint)
 				break
 			}
 
 			for _, alias := range endpoint.Aliases {
 				if alias == name {
-					data.ip = endpoint.IPAddress
+					data.ip = dockerEndpointIP(endpoint)
 					break
 				}
 			}
@@ -655,7 +670,7 @@ func (w *dockerWatcherImpl) parseContainerData(container *container.InspectRespo
 		}
 
 		for _, endpoint := range container.NetworkSettings.Networks {
-			data.ip = endpoint.IPAddress
+			data.ip = dockerEndpointIP(endpoint)
 			break
 		}
 	}

--- a/server/docker_test.go
+++ b/server/docker_test.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerEndpointIP(t *testing.T) {
+	t.Run("prefers IPv4 when both exist", func(t *testing.T) {
+		endpoint := &network.EndpointSettings{
+			IPAddress:         "10.0.0.10",
+			GlobalIPv6Address: "fd00::10",
+		}
+		assert.Equal(t, "10.0.0.10", dockerEndpointIP(endpoint))
+	})
+
+	t.Run("falls back to IPv6 when IPv4 absent", func(t *testing.T) {
+		endpoint := &network.EndpointSettings{
+			GlobalIPv6Address: "fd00::20",
+		}
+		assert.Equal(t, "fd00::20", dockerEndpointIP(endpoint))
+	})
+
+	t.Run("returns empty when endpoint missing", func(t *testing.T) {
+		assert.Empty(t, dockerEndpointIP(nil))
+	})
+}
+
+func TestDockerBackendEndpoint(t *testing.T) {
+	assert.Equal(t, "10.0.0.10:25565", dockerBackendEndpoint("10.0.0.10", 25565))
+	assert.Equal(t, "[fd00::20]:25565", dockerBackendEndpoint("fd00::20", 25565))
+}
+
+func TestDockerWatcherParseContainerData_IPSelection(t *testing.T) {
+	makeInspect := func(labels map[string]string, networks map[string]*network.EndpointSettings) *container.InspectResponse {
+		return &container.InspectResponse{
+			Config: &container.Config{
+				Labels: labels,
+			},
+			NetworkSettings: &container.NetworkSettings{
+				Networks: networks,
+			},
+			ContainerJSONBase: &container.ContainerJSONBase{
+				ID:   "abc123",
+				Name: "example",
+				State: &container.State{
+					Running: true,
+				},
+			},
+		}
+	}
+
+	w := &dockerWatcherImpl{}
+
+	t.Run("uses ipv4 for single-network container", func(t *testing.T) {
+		inspect := makeInspect(
+			map[string]string{
+				DockerRouterLabelHost: "mc.example.com",
+			},
+			map[string]*network.EndpointSettings{
+				"v6net": {
+					IPAddress:         "172.20.0.2",
+					GlobalIPv6Address: "fd00::2",
+				},
+			},
+		)
+
+		data, ok := w.parseContainerData(inspect)
+		require.True(t, ok)
+		assert.Equal(t, "172.20.0.2", data.ip)
+		assert.Equal(t, uint64(25565), data.port)
+	})
+
+	t.Run("uses ipv6 for single-network container when ipv4 absent", func(t *testing.T) {
+		inspect := makeInspect(
+			map[string]string{
+				DockerRouterLabelHost: "mc.example.com",
+			},
+			map[string]*network.EndpointSettings{
+				"v6net": {
+					GlobalIPv6Address: "fd00::2",
+				},
+			},
+		)
+
+		data, ok := w.parseContainerData(inspect)
+		require.True(t, ok)
+		assert.Equal(t, "fd00::2", data.ip)
+	})
+
+	t.Run("uses ipv6 for selected network when network label is set", func(t *testing.T) {
+		inspect := makeInspect(
+			map[string]string{
+				DockerRouterLabelHost:    "mc.example.com",
+				DockerRouterLabelNetwork: "v6net",
+			},
+			map[string]*network.EndpointSettings{
+				"other": {
+					IPAddress: "172.20.0.5",
+				},
+				"v6net": {
+					GlobalIPv6Address: "fd00::6",
+				},
+			},
+		)
+
+		data, ok := w.parseContainerData(inspect)
+		require.True(t, ok)
+		assert.Equal(t, "fd00::6", data.ip)
+	})
+
+	t.Run("rejects container with no routable ip while running", func(t *testing.T) {
+		inspect := makeInspect(
+			map[string]string{
+				DockerRouterLabelHost: "mc.example.com",
+			},
+			map[string]*network.EndpointSettings{
+				"v6net": {},
+			},
+		)
+
+		_, ok := w.parseContainerData(inspect)
+		assert.False(t, ok)
+	})
+}


### PR DESCRIPTION
Docker-discovered routes were skipped when a container only exposed an IPv6 address, because discovery only read `endpoint.IPAddress` (IPv4). This broke discoverability for IPv6-only and IPAM-assigned IPv6 container setups.

This change updates Docker parsing to prefer IPv4 when present and fall back to `GlobalIPv6Address` when IPv4 is empty. It also switches Docker backend endpoint construction to `net.JoinHostPort` so IPv6 backends are always formatted correctly as `[addr]:port`.

## Tests
- Added `server/docker_test.go` with coverage for:
  - IPv4 precedence when both addresses exist
  - IPv6 fallback when IPv4 is absent
  - IPv6 selection on an explicitly labeled network
  - rejection when no routable address is available
  - IPv6 endpoint formatting via backend host:port generation
- Ran `go test ./server -count=1`

Fixes: #574