### PR TITLE
fix: validate UTF-8 strings and sanitize Prometheus metric labels

### DIFF
--- a/mcproto/read.go
+++ b/mcproto/read.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"unicode/utf8"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/text/encoding/unicode"
@@ -183,7 +185,12 @@ func ReadUTF16BEString(reader io.Reader, symbolLen uint16) (string, error) {
 		return "", err
 	}
 
-	return string(result), nil
+	str := string(result)
+	if !utf8.ValidString(str) {
+		return "", errors.New("string is not valid UTF-8")
+	}
+
+	return str, nil
 }
 
 func ReadFrame(reader io.Reader, addr net.Addr) (*Frame, error) {
@@ -301,7 +308,12 @@ func ReadString(reader io.Reader) (string, error) {
 		strBuilder.WriteByte(b[0])
 	}
 
-	return strBuilder.String(), nil
+	str := strBuilder.String()
+	if !utf8.ValidString(str) {
+		return "", errors.New("string is not valid UTF-8")
+	}
+
+	return str, nil
 }
 
 func ReadByte(reader io.Reader) (byte, error) {

--- a/mcproto/read_test.go
+++ b/mcproto/read_test.go
@@ -16,6 +16,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestReadString(t *testing.T) {
+	t.Run("Valid UTF-8", func(t *testing.T) {
+		var buf bytes.Buffer
+		_ = WriteString(&buf, "mc.example.com")
+		str, err := ReadString(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, "mc.example.com", str)
+	})
+
+	t.Run("Invalid UTF-8", func(t *testing.T) {
+		var buf bytes.Buffer
+		invalidBytes := []byte{0x01, 0xd9, 0x20, 0x34, 0xc3, 0x58, 0xdc, 0x0b, 0x85, 0xfe, 0x6b, 0xfd, 0x3b, 0x73, 0x07, 0x11, 0xb4, 0x39, 0x4b, 0x43, 0x2d}
+		_ = WriteVarInt(&buf, int32(len(invalidBytes)))
+		buf.Write(invalidBytes)
+
+		str, err := ReadString(&buf)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not valid UTF-8")
+		assert.Empty(t, str)
+	})
+}
+
 func TestReadVarInt(t *testing.T) {
 	tests := []struct {
 		Name     string

--- a/server/connector.go
+++ b/server/connector.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"golang.ngrok.com/ngrok"
 	"golang.ngrok.com/ngrok/config"
@@ -524,6 +526,13 @@ func (c *Connector) readPlayerInfo(protocolVersion mcproto.ProtocolVersion, buff
 	}
 }
 
+func sanitizeUTF8(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	return strings.ToValidUTF8(s, "")
+}
+
 func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress string, playerInfo *PlayerInfo, backendHostPort string, scalingTarget string, cleanupMetrics bool, checkScaleDown bool) {
 	if c.connectionNotifier != nil {
 		err := c.connectionNotifier.NotifyDisconnected(c.ctx, clientAddr, serverAddress, playerInfo, backendHostPort)
@@ -538,16 +547,16 @@ func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress 
 
 		c.activeConnections.Decrement(backendHostPort)
 		c.metrics.ServerActiveConnections.
-			With("server_address", serverAddress).
+			With("server_address", sanitizeUTF8(serverAddress)).
 			Set(float64(c.activeConnections.GetCount(backendHostPort)))
 
 		c.scaleActiveConnections.Decrement(scalingTarget)
 
 		if c.recordLogins && playerInfo != nil {
 			c.metrics.ServerActivePlayer.
-				With("player_name", playerInfo.Name).
-				With("player_uuid", playerInfo.Uuid.String()).
-				With("server_address", serverAddress).
+				With("player_name", sanitizeUTF8(playerInfo.Name)).
+				With("player_uuid", sanitizeUTF8(playerInfo.Uuid.String())).
+				With("server_address", sanitizeUTF8(serverAddress)).
 				Set(0)
 		}
 	}
@@ -714,7 +723,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 		}
 	}
 
-	c.metrics.ConnectionsBackend.With("host", resolvedHost).Add(1)
+	c.metrics.ConnectionsBackend.With("host", sanitizeUTF8(resolvedHost)).Add(1)
 
 	c.metrics.ActiveConnections.Set(float64(
 		atomic.AddInt32(&c.totalActiveConnections, 1)))
@@ -722,7 +731,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 	c.activeConnections.Increment(backendHostPort)
 	c.scaleActiveConnections.Increment(scalingTarget)
 	c.metrics.ServerActiveConnections.
-		With("server_address", serverAddress).
+		With("server_address", sanitizeUTF8(serverAddress)).
 		Set(float64(c.activeConnections.GetCount(backendHostPort)))
 
 	if c.recordLogins && playerInfo != nil {
@@ -733,15 +742,15 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			Info("Player attempted to login to server")
 
 		c.metrics.ServerActivePlayer.
-			With("player_name", playerInfo.Name).
-			With("player_uuid", playerInfo.Uuid.String()).
-			With("server_address", serverAddress).
+			With("player_name", sanitizeUTF8(playerInfo.Name)).
+			With("player_uuid", sanitizeUTF8(playerInfo.Uuid.String())).
+			With("server_address", sanitizeUTF8(serverAddress)).
 			Set(1)
 
 		c.metrics.ServerLogins.
-			With("player_name", playerInfo.Name).
-			With("player_uuid", playerInfo.Uuid.String()).
-			With("server_address", serverAddress).
+			With("player_name", sanitizeUTF8(playerInfo.Name)).
+			With("player_uuid", sanitizeUTF8(playerInfo.Uuid.String())).
+			With("server_address", sanitizeUTF8(serverAddress)).
 			Add(1)
 	}
 

--- a/server/connector_test.go
+++ b/server/connector_test.go
@@ -188,3 +188,37 @@ func TestConnectorMOTDFallback(t *testing.T) {
 	assert.Contains(t, jsonStr, "fallback asleep")
 	assert.False(t, scaleUpCalled, "Waker should NOT be called for a status request")
 }
+
+func TestConnectorNonUTF8Handshake(t *testing.T) {
+	routes := NewRoutes(t.Context())
+	downScaler := NewDownScaler(false, 5*time.Second)
+
+	metricsBuilder := prometheusMetricsBuilder{}
+	c := NewConnector(t.Context(), routes, downScaler, metricsBuilder.BuildConnectorMetrics(), false, false, nil)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	go c.acceptConnections(ln, 100, 0)
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	invalidBytes := []byte{0x01, 0xd9, 0x20, 0x34, 0xc3, 0x58, 0xdc, 0x0b, 0x85, 0xfe, 0x6b, 0xfd, 0x3b, 0x73, 0x07, 0x11, 0xb4, 0x39, 0x4b, 0x43, 0x2d}
+	err = writeTestPacket(clientConn, 0x00, func(w io.Writer) {
+		_ = mcproto.WriteVarInt(w, 758)
+		_ = mcproto.WriteVarInt(w, int32(len(invalidBytes)))
+		w.Write(invalidBytes)
+		w.Write([]byte{0x63, 0xdd})
+		_ = mcproto.WriteVarInt(w, 1)
+	})
+	require.NoError(t, err)
+
+	// Wait briefly for connection processing to finish without panicking
+	_ = clientConn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	buf := make([]byte, 10)
+	_, _ = clientConn.Read(buf)
+}
+


### PR DESCRIPTION
### Why
Internet port scanners sending non-UTF-8 raw binary data in Minecraft handshake packets cause `mc-router` to panic and crash when Prometheus metrics are enabled (#582). The Prometheus client library (`client_golang`) validates label values with `utf8.ValidString` and panics on invalid UTF-8 strings.

### Approach
- **Protocol validation (`mcproto`)**: Added `utf8.ValidString` checks in `mcproto.ReadString` and `ReadUTF16BEString`. Handshakes or login packets with invalid UTF-8 are rejected immediately at the protocol level, logging the error and closing the connection cleanly.
- **Metric label sanitization (`server`)**: Added UTF-8 sanitization (`strings.ToValidUTF8`) for dynamic metric labels (`server_address`, `player_name`, `player_uuid`, `host`) in `connector.go` as defense-in-depth against Prometheus label validation panics.
- **Unit tests**: Added tests in `mcproto` and `server` packages verifying that non-UTF-8 strings return decoding errors and are handled gracefully without panicking.

Fixes #582