### PR TITLE
Various code refactoring and improvements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,7 +47,7 @@ dockers_v2:
       - linux/arm/v6
     tags:
       - "{{ .Version }}"
-      - "latest"
+      - "{{ if not .Prerelease }}latest{{ end }}"
     labels:
       org.opencontainers.image.authors: "Geoff Bourne <itzgeoff@gmail.com>"
       org.opencontainers.image.title: "mc-router"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,13 +18,17 @@ Start mc-router directly in the devcontainer.
 
 Verified with skaffold v2.23.0
 
-```
+```shell
 skaffold dev --kube-context=docker-desktop --default-repo=gcr.io/YOURS
 ```
 
 - `YOURS` with your github username or the repo entirely
 
-Also be sure to kubectl apply the minecraft deployment such as `docs/k8s-mc-with-default.yaml`
+Also be sure to kubectl apply the minecraft deployment such as `docs/k8s-mc-deployment.yaml` or `docs/k8s-mc-sts.yaml`, if using autoscaling.
+
+> [!NOTE]
+> The dev image build performed by skaffold uses [ko](https://skaffold.dev/docs/builders/builder-types/ko/), which 
+> does not use the `Dockerfile` in the repo; however, the base image is [the same](https://github.com/chainguard-images/images/tree/main/images/static).
 
 ## Manual test cases
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,3 +119,36 @@ When applying the `mc-router.host` label to containers to be auto-discovered, it
 
 Run one of the labeled services by clicking the run icon in the gutter.
 
+## Docker Swarm
+
+In order to make development images available to the mc-router service, you need to run an in-cluster retry and push to it.
+
+Start an in-cluster retry service:
+
+```shell
+docker service create \
+  --name registry \
+  --publish published=5000,target=5000 \
+  registry:2
+```
+
+Build the image like normal and tag it as `localhost:5000/itzg/mc-router:r1` using the tag as a distinct version to test.
+
+```shell
+docker tag itzg/mc-router:latest localhost:5000/itzg/mc-router:r1
+```
+
+Finally, push the image to the in-cluster retry service:
+
+```shell
+docker push localhost:5000/itzg/mc-router:r1
+```
+
+Be sure to update the `image` in the stack's compose file, such as
+
+```yaml
+  router:
+     image: 127.0.0.1:5000/itzg/mc-router:r1
+     environment:
+        IN_DOCKER_SWARM: "true"
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,3 +25,22 @@ skaffold dev --kube-context=docker-desktop --default-repo=gcr.io/YOURS
 - `YOURS` with your github username or the repo entirely
 
 Also be sure to kubectl apply the minecraft deployment such as `docs/k8s-mc-with-default.yaml`
+
+## Manual test cases
+
+### Docker discovery with auto-scaling
+
+1. Build the image given `Dockerfile` and tag it as `itzg/mc-router`
+2. Start examples/docker-autoscale-multi/compose.yml
+3. Wait for initial scale down of vanilla container
+4. With Minecraft client, do a ping/list and ensure asleep MOTD comes back
+   - Nothing happens with scaling or timer
+5. Connect
+   - Watch for scaling up of vanilla container
+   - Client should fully connect after vanilla container is up
+6. Stay connected longer than the 1 minute scale down timer
+   - Ensure vanilla container is still up
+7. Disconnect
+8. Server list refresh to cause ping
+   - ensure scale-down timer started again
+9. Wait for scale down of vanilla container

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,7 +16,12 @@ Start mc-router directly in the devcontainer.
 
 ## Using skaffold
 
-Verified with skaffold v2.23.0
+
+For "in-cluster development" it's convenient to use https://skaffold.dev. Any changes to Go source code
+will trigger a go build, new container image pushed to registry with a new tag, and refresh in Kubernetes
+with the image tag used in the deployment transparently updated to the new tag and thus new pod created pulling new images,
+as configured by [skaffold.yaml](skaffold.yaml):
+
 
 ```shell
 skaffold dev --kube-context=docker-desktop --default-repo=gcr.io/YOURS
@@ -24,11 +29,22 @@ skaffold dev --kube-context=docker-desktop --default-repo=gcr.io/YOURS
 
 - `YOURS` with your github username or the repo entirely
 
+Verified with skaffold v2.23.0
+
 Also be sure to kubectl apply the minecraft deployment such as `docs/k8s-mc-deployment.yaml` or `docs/k8s-mc-sts.yaml`, if using autoscaling.
 
 > [!NOTE]
 > The dev image build performed by skaffold uses [ko](https://skaffold.dev/docs/builders/builder-types/ko/), which 
 > does not use the `Dockerfile` in the repo; however, the base image is [the same](https://github.com/chainguard-images/images/tree/main/images/static).
+
+    skaffold dev
+
+> [!TIP]
+> When using Google Cloud (GCP), first create a _Docker Artifact Registry_,
+> then add the _Artifact Registry Reader_ Role to the _Compute Engine default service account_ of your _GKE `clusterService` Account_ (to avoid error like "container mc-router is waiting to start: ...-docker.pkg.dev/... can't be pulled"),
+> then use e.g. `gcloud auth configure-docker europe-docker.pkg.dev` or equivalent one time (to create a `~/.docker/config.json`),
+> and then use e.g. `--default-repo=europe-docker.pkg.dev/YOUR-PROJECT/YOUR-ARTIFACT-REGISTRY` option for `skaffold dev`.
+
 
 ## Manual test cases
 
@@ -48,3 +64,58 @@ Also be sure to kubectl apply the minecraft deployment such as `docs/k8s-mc-depl
 8. Server list refresh to cause ping
    - ensure scale-down timer started again
 9. Wait for scale down of vanilla container
+
+## Confirming golreaser build
+
+```shell
+goreleaser release --snapshot --clean
+```
+
+### Performing snapshot release with Docker
+
+```bash
+docker run -it --rm \
+  -v ${PWD}:/build -w /build \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  goreleaser/goreleaser \
+  release --snapshot --clean
+```
+
+## Building locally with Docker
+
+```bash
+docker build -t mc-router .
+```
+
+## Build locally without Docker
+
+After [installing Go](https://go.dev/doc/install) and doing a `go mod download` to install all required prerequisites, just like the [Dockerfile](Dockerfile) does, you can:
+
+```bash
+make test # go test -v ./...
+go build ./cmd/mc-router/
+```
+
+## Running in devcontainer
+
+This approach is useful for testing changes for [Docker auto scaling](#docker-auto-scale-updown).
+
+With IntelliJ Ultimate, [use these instructions](https://www.jetbrains.com/help/idea/start-dev-container-inside-ide.html). It is recommended to use the option to mount sources.
+
+![Start devcontainer in IntelliJ](docs/intellij-devcontainer.png)
+
+Use the example compose file [in examples/docker-discovery](examples/docker-discovery/compose.yml) or similar with `network_mode` set to "bridge" to ensure that the mc-router instance running within the devcontainer can reach the backend servers.
+
+When applying the `mc-router.host` label to containers to be auto-discovered, it's easiest to use an external host of "localhost":
+
+```yaml
+  vanilla:
+    image: itzg/minecraft-server
+    environment:
+      EULA: "TRUE"
+    labels:
+      mc-router.host: "localhost"
+```
+
+Run one of the labeled services by clicking the run icon in the gutter.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,6 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -buildvcs=false ./cmd/mc-router
 
-FROM alpine AS certs
-RUN apk add -U \
-    ca-certificates \
-    tzdata
-
-FROM scratch
+FROM cgr.dev/chainguard/static
 ENTRYPOINT ["/mc-router"]
-COPY --from=certs /etc/ssl/certs/ /etc/ssl/certs
-COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /build/mc-router /mc-router

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,8 +1,17 @@
-FROM cgr.dev/chainguard/static
+# 1. Alias the architectures to their corresponding base images
+FROM cgr.dev/chainguard/static AS base-amd64
+FROM cgr.dev/chainguard/static AS base-arm64
+# Fall back to a light 32-bit ARM image (e.g. Alpine) for arm/v6
+FROM alpine:3.19 AS base-armv6
+
+# 2. Capture automatic buildx arguments
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+# 3. Dynamically load the base image stage
+FROM base-${TARGETARCH}${TARGETVARIANT} AS final
 
 ARG TARGETPLATFORM
 
-COPY --from=certs /etc/ssl/certs/ /etc/ssl/certs
-COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
 COPY $TARGETPLATFORM/mc-router /
 ENTRYPOINT ["/mc-router"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,8 +1,15 @@
-FROM cgr.dev/chainguard/static
+# 1. Alias the architectures to their corresponding base images
+FROM cgr.dev/chainguard/static AS base-amd64
+FROM cgr.dev/chainguard/static AS base-arm64
+# Fall back to a light 32-bit ARM image (e.g. Alpine) for arm/v6
+FROM alpine:3.19 AS base-armv6
 
-ARG TARGETPLATFORM
+# 2. Capture automatic buildx arguments
+ARG TARGETARCH
+ARG TARGETVARIANT
 
-COPY --from=certs /etc/ssl/certs/ /etc/ssl/certs
-COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+# 3. Dynamically load the base image stage
+FROM base-${TARGETARCH}${TARGETVARIANT} AS final
+
 COPY $TARGETPLATFORM/mc-router /
 ENTRYPOINT ["/mc-router"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,9 +1,4 @@
-FROM alpine AS certs
-RUN apk add -U \
-    ca-certificates \
-    tzdata
-
-FROM scratch
+FROM cgr.dev/chainguard/static
 
 ARG TARGETPLATFORM
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,15 +1,8 @@
-# 1. Alias the architectures to their corresponding base images
-FROM cgr.dev/chainguard/static AS base-amd64
-FROM cgr.dev/chainguard/static AS base-arm64
-# Fall back to a light 32-bit ARM image (e.g. Alpine) for arm/v6
-FROM alpine:3.19 AS base-armv6
+FROM cgr.dev/chainguard/static
 
-# 2. Capture automatic buildx arguments
-ARG TARGETARCH
-ARG TARGETVARIANT
+ARG TARGETPLATFORM
 
-# 3. Dynamically load the base image stage
-FROM base-${TARGETARCH}${TARGETVARIANT} AS final
-
+COPY --from=certs /etc/ssl/certs/ /etc/ssl/certs
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
 COPY $TARGETPLATFORM/mc-router /
 ENTRYPOINT ["/mc-router"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-.PHONY: test
-test:
-	go test ./...
-
-.PHONY: release
-release:
-	curl -sL https://git.io/goreleaser | bash

--- a/README.md
+++ b/README.md
@@ -193,12 +193,16 @@ When using in Docker, make sure to volume mount the Docker socket into the conta
 #### User access to docker socket
 
 > [!IMPORTANT]
-> If getting "Permission denied" errors for the Docker socket, change add the group ID of the docker system user to match your system. 
-> Group ID 999 is the default for Docker's native installatino on Linux. When using Docker Desktop it tends to assign the root group as the socket owner.
+> If getting "Permission denied" errors for the Docker socket, `/var/run/docker.sock`, then it is because **the image now runs the container as a non-root user by default**. The Docker socket is not readable or writable a regular user/group.
+> Refer to one of the following notes for solutions.
+
+> [!NOTE]
+> One solution is to add the group ID of the docker system user to match your system. 
+> Group ID 999 is the default for Docker's native installation on Linux. When using Docker Desktop it tends to assign the **root** group through as the socket owner.
 >
 > Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host.
 >
-> Typically on Linux, use
+> Typically on Linux, add the following to the container/service definition:
 > ```yaml
 > group_add:
 >   # docker system user's group ID
@@ -211,10 +215,20 @@ When using in Docker, make sure to volume mount the Docker socket into the conta
 >   # root user's group ID
 >   - "0"
 > ```
+> 
+> You can also simply "revert" to the previous behavior add add the following to the container/service definition:
+> ```yaml
+> user: root
+> ```
+> to the container/service definition.
+ 
 
-With Docker Swarm and even regular Docker, a socket proxy can be used such as [this example compose file](examples/swarm/compose.yml).
+> [!NOTE]
+> If you would like to instead isolate the elevated access to the Docker socket, a socket proxy can be used such as [this example compose file for Docker Swarm](examples/swarm/compose.yml) and [this example Docker Compose file](examples/docker-autoscale-socket-proxy/compose.yml).
 
-These are the labels scanned:
+### Docker discovery labels
+
+These are the labels on the containers are scanned for discovery and auto-scaling:
 
 - `mc-router.host`: Used to configure the hostname the Minecraft clients would use to connect to the server. The container/service endpoint will be used as the routed backend. You can use more than one hostname by splitting it with a comma or newline. Whitespace around commas is automatically trimmed. For example: `"host1.com,host2.com"`, `"host1.com, host2.com"`, or `"host1.com\nhost2.com"`.
 - `mc-router.port`: This value must be set to the port the Minecraft server is listening on. The default value is 25565.

--- a/README.md
+++ b/README.md
@@ -193,11 +193,26 @@ When using in Docker, make sure to volume mount the Docker socket into the conta
 #### User access to docker socket
 
 > [!IMPORTANT]
-> If getting "Permission denied" errors for the docker socket change this group ID to match your system. 
-> Group ID 999 is the default for Docker Desktop's VM, which is why that is used in the example.
+> If getting "Permission denied" errors for the Docker socket, change add the group ID of the docker system user to match your system. 
+> Group ID 999 is the default for Docker's native installatino on Linux. When using Docker Desktop it tends to assign the root group as the socket owner.
 >
-> Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host user: ":999". Note the colon before the group ID since
-> the `user` syntax is `user: <user>:<group>`
+> Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host.
+>
+> Typically on Linux, use
+> ```yaml
+> group_add:
+>   # docker system user's group ID
+>   - "999"
+> ```
+> 
+> or with Docker Desktop
+> ```yaml
+> group_add:
+>   # root user's group ID
+>   - "0"
+> ```
+
+With Docker Swarm and even regular Docker, a socket proxy can be used such as [this example compose file](examples/swarm/compose.yml).
 
 These are the labels scanned:
 
@@ -242,13 +257,15 @@ Behavior:
 
 #### Example Docker deployment
 
-Refer to [this example docker-compose.yml](docs/sd-docker.docker-compose.yml) to see how to
+Refer to [this example compose file](docs/sd-docker.docker-compose.yml) to see how to
 configure two different Minecraft servers and a `mc-router` instance for use with Docker service discovery.
 
 #### Example Docker Swarm deployment
 
-Refer to [this example docker-compose.yml](docs/swarm.docker-compose.yml) to see how to
+Refer to [this example compose file](examples/swarm/compose.yml) to see how to
 configure two different Minecraft servers and a `mc-router` instance for use with Docker Swarm service discovery.
+
+Refer to the [section above](#user-access-to-docker-socket) for information on how to configure the Docker socket access.
 
 ### Webhook Auto Scale
 

--- a/README.md
+++ b/README.md
@@ -881,69 +881,7 @@ In this case the `status` is `"failed-backend-connection"` indicating that a bac
 
 ## Development
 
-### Building locally with Docker
-
-```bash
-docker build -t mc-router .
-```
-
-### Build locally without Docker
-
-After [installing Go](https://go.dev/doc/install) and doing a `go mod download` to install all required prerequisites, just like the [Dockerfile](Dockerfile) does, you can:
-
-```bash
-make test # go test -v ./...
-go build ./cmd/mc-router/
-```
-
-### Skaffold
-
-For "in-cluster development" it's convenient to use https://skaffold.dev. Any changes to Go source code
-will trigger a go build, new container image pushed to registry with a new tag, and refresh in Kubernetes
-with the image tag used in the deployment transparently updated to the new tag and thus new pod created pulling new images,
-as configured by [skaffold.yaml](skaffold.yaml):
-
-    skaffold dev
-
-When using Google Cloud (GCP), first create a _Docker Artifact Registry_,
-then add the _Artifact Registry Reader_ Role to the _Compute Engine default service account_ of your _GKE `clusterService` Account_ (to avoid error like "container mc-router is waiting to start: ...-docker.pkg.dev/... can't be pulled"),
-then use e.g. `gcloud auth configure-docker europe-docker.pkg.dev` or equivalent one time (to create a `~/.docker/config.json`),
-and then use e.g. `--default-repo=europe-docker.pkg.dev/YOUR-PROJECT/YOUR-ARTIFACT-REGISTRY` option for `skaffold dev`.
-
-### Running in devcontainer
-
-This approach is useful for testing changes for [Docker auto scaling](#docker-auto-scale-updown).
-
-With IntelliJ Ultimate, [use these instructions](https://www.jetbrains.com/help/idea/start-dev-container-inside-ide.html). It is recommended to use the option to mount sources.
-
-![Start devcontainer in IntelliJ](docs/intellij-devcontainer.png)
-
-Use the example compose file [in examples/docker-discovery](examples/docker-discovery/compose.yml) or similar with `network_mode` set to "bridge" to ensure that the mc-router instance running within the devcontainer can reach the backend servers.
-
-When applying the `mc-router.host` label to containers to be auto-discovered, it's easiest to use an external host of "localhost":
-
-```yaml
-  vanilla:
-    image: itzg/minecraft-server
-    environment:
-      EULA: "TRUE"
-    labels:
-      mc-router.host: "localhost"
-```
-
-Run one of the labeled services by clicking the run icon in the gutter.
-
-
-
-### Performing snapshot release with Docker
-
-```bash
-docker run -it --rm \
-  -v ${PWD}:/build -w /build \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  goreleaser/goreleaser \
-  release --snapshot --rm-dist
-```
+Refer to [DEVELOPMENT.md](DEVELOPMENT.md)
 
 ## Related Projects
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ When using in Docker, make sure to volume mount the Docker socket into the conta
       - /var/run/docker.sock:/var/run/docker.sock:ro
 ```
 
+#### User access to docker socket
+
+> [!IMPORTANT]
+> If getting "Permission denied" errors for the docker socket change this group ID to match your system. 
+> Group ID 999 is the default for Docker Desktop's VM, which is why that is used in the example.
+>
+> Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host user: ":999". Note the colon before the group ID since
+> the `user` syntax is `user: <user>:<group>`
+
 These are the labels scanned:
 
 - `mc-router.host`: Used to configure the hostname the Minecraft clients would use to connect to the server. The container/service endpoint will be used as the routed backend. You can use more than one hostname by splitting it with a comma or newline. Whitespace around commas is automatically trimmed. For example: `"host1.com,host2.com"`, `"host1.com, host2.com"`, or `"host1.com\nhost2.com"`.

--- a/docs/k8s-deployment.yaml
+++ b/docs/k8s-deployment.yaml
@@ -54,7 +54,6 @@ spec:
       containers:
       - image: itzg/mc-router
         name: mc-router
-        # Add "--auto-scale-up" here for https://github.com/itzg/mc-router/#auto-scale-up
         args:
           - --api-binding
           - :8080
@@ -64,6 +63,16 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: DEBUG
+            value: "false"
+          - name: AUTO_SCALE_DOWN
+            value: "true"
+          - name: AUTO_SCALE_UP
+            value: "true"
+          - name: AUTO_SCALE_DOWN_AFTER
+            value: "1m"
+          - name: AUTO_SCALE_ASLEEP_MOTD
+            value: "Server is asleep. Join again to wake it up!"
         ports:
         - name: proxy
           containerPort: 25565

--- a/docs/k8s-mc-deployment.yaml
+++ b/docs/k8s-mc-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: mc-latest
   annotations:
     "mc-router.itzg.me/defaultServer": "true"
+    # Only enable these for testing since auto-scaling is not yet supported for deployment types
+#    "mc-router.itzg.me/autoScaleUp": "true"
+#    "mc-router.itzg.me/autoScaleDown": "true"
 spec:
   type: NodePort
   ports:
@@ -45,7 +48,8 @@ kind: Service
 metadata:
   name: mc-snapshot
   annotations:
-    "mc-router.itzg.me/externalServerName": "snapshot.your.domain"
+    # Replace localhost with public hostname of your mc-router host or port-forwarded address
+    "mc-router.itzg.me/externalServerName": "127.0.0.2,127.0.0.3"
 spec:
   type: NodePort
   ports:

--- a/docs/k8s-mc-sts.yaml
+++ b/docs/k8s-mc-sts.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mc-latest
+  annotations:
+    "mc-router.itzg.me/defaultServer": "true"
+    "mc-router.itzg.me/autoScaleUp": "true"
+    "mc-router.itzg.me/autoScaleDown": "true"
+spec:
+  type: NodePort
+  ports:
+  - port: 25565
+    name: minecraft
+  selector:
+    app: mc-latest
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: mc-latest
+  labels:
+    app: mc-latest
+spec:
+  selector:
+    matchLabels:
+      app: mc-latest
+  serviceName: "mc-latest"
+  template:
+    metadata:
+      labels:
+        app: mc-latest
+    spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+      - image: itzg/minecraft-server
+        name: mc-latest
+        env:
+        - name: EULA
+          value: "TRUE"
+        ports:
+        - containerPort: 25565
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mc-snapshot
+  annotations:
+    # Replace localhost with public hostname of your mc-router host or port-forwarded address
+    "mc-router.itzg.me/externalServerName": "127.0.0.2,127.0.0.3"
+    # auto scale
+    "mc-router.itzg.me/autoScale": "true"
+spec:
+  type: NodePort
+  ports:
+  - port: 25565
+    name: minecraft
+  selector:
+    app: mc-snapshot
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: mc-snapshot
+  labels:
+    app: mc-snapshot
+spec:
+  selector:
+    matchLabels:
+      app: mc-snapshot
+  serviceName: "mc-snapshot"
+  template:
+    metadata:
+      labels:
+        app: mc-snapshot
+    spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+      - image: itzg/minecraft-server
+        name: mc-snapshot
+        env:
+        - name: EULA
+          value: "TRUE"
+        - name: VERSION
+          value: "SNAPSHOT"
+        ports:
+        - containerPort: 25565

--- a/docs/sd-docker.docker-compose.yml
+++ b/docs/sd-docker.docker-compose.yml
@@ -28,6 +28,10 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    # If getting "Permission denied" errors for the docker socket
+    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
+    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
+    user: ":999"
 
 volumes:
   mcfoodata:

--- a/docs/sd-docker.docker-compose.yml
+++ b/docs/sd-docker.docker-compose.yml
@@ -28,10 +28,9 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # If getting "Permission denied" errors for the docker socket
-    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
-    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
-    user: ":999"
+    # Refer to the "User access to docker socket" section in the README
+    group_add:
+      - "0"
 
 volumes:
   mcfoodata:

--- a/docs/swarm.docker-compose.yml
+++ b/docs/swarm.docker-compose.yml
@@ -13,6 +13,10 @@ services:
       - minecraft
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    # If getting "Permission denied" errors for the docker socket
+    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
+    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
+    user: ":999"
 
   mcfoobar:
     image: itzg/minecraft-server:latest

--- a/examples/docker-autoscale-multi/compose.yml
+++ b/examples/docker-autoscale-multi/compose.yml
@@ -8,6 +8,8 @@ services:
       AUTO_SCALE_DOWN_AFTER: 1m
       AUTO_SCALE_ASLEEP_MOTD: "Server is asleep. Join again to wake it up!"
       DEBUG: true
+    # Uncomment this if getting "Permission denied" errors for the docker socket
+#    user: root
     ports:
       - "25565:25565"
     volumes:

--- a/examples/docker-autoscale-multi/compose.yml
+++ b/examples/docker-autoscale-multi/compose.yml
@@ -12,10 +12,9 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # If getting "Permission denied" errors for the docker socket
-    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
-    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
-    user: ":999"
+    # Refer to the "User access to docker socket" section in the README
+    group_add:
+      - "0"
 
   vanilla:
     image: itzg/minecraft-server

--- a/examples/docker-autoscale-multi/compose.yml
+++ b/examples/docker-autoscale-multi/compose.yml
@@ -1,6 +1,6 @@
 services:
   router:
-    image: itzg/mc-router:1.46.0-rc1
+    image: itzg/mc-router
     environment:
       IN_DOCKER: true
       AUTO_SCALE_DOWN: true

--- a/examples/docker-autoscale-multi/compose.yml
+++ b/examples/docker-autoscale-multi/compose.yml
@@ -5,8 +5,9 @@ services:
       IN_DOCKER: true
       AUTO_SCALE_DOWN: true
       AUTO_SCALE_UP: true
-      AUTO_SCALE_DOWN_AFTER: 2h
+      AUTO_SCALE_DOWN_AFTER: 1m
       AUTO_SCALE_ASLEEP_MOTD: "Server is asleep. Join again to wake it up!"
+      DEBUG: true
     ports:
       - "25565:25565"
     volumes:

--- a/examples/docker-autoscale-multi/compose.yml
+++ b/examples/docker-autoscale-multi/compose.yml
@@ -1,6 +1,6 @@
 services:
   router:
-    image: itzg/mc-router
+    image: itzg/mc-router:1.46.0-rc1
     environment:
       IN_DOCKER: true
       AUTO_SCALE_DOWN: true
@@ -8,12 +8,15 @@ services:
       AUTO_SCALE_DOWN_AFTER: 1m
       AUTO_SCALE_ASLEEP_MOTD: "Server is asleep. Join again to wake it up!"
       DEBUG: true
-    # Uncomment this if getting "Permission denied" errors for the docker socket
-#    user: root
     ports:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    # If getting "Permission denied" errors for the docker socket
+    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
+    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
+    user: ":999"
+
   vanilla:
     image: itzg/minecraft-server
     environment:

--- a/examples/docker-autoscale-multi/compose.yml
+++ b/examples/docker-autoscale-multi/compose.yml
@@ -1,0 +1,22 @@
+services:
+  router:
+    image: itzg/mc-router
+    environment:
+      IN_DOCKER: true
+      AUTO_SCALE_DOWN: true
+      AUTO_SCALE_UP: true
+      AUTO_SCALE_DOWN_AFTER: 2h
+      AUTO_SCALE_ASLEEP_MOTD: "Server is asleep. Join again to wake it up!"
+    ports:
+      - "25565:25565"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+  vanilla:
+    image: itzg/minecraft-server
+    environment:
+      EULA: "TRUE"
+    labels:
+      mc-router.host: |
+        localhost
+        127.0.0.2
+

--- a/examples/docker-autoscale-socket-proxy/compose.yml
+++ b/examples/docker-autoscale-socket-proxy/compose.yml
@@ -1,0 +1,41 @@
+services:
+  # Isolate root-level access to the docker socket
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    user: root
+    environment:
+      CONTAINERS: 1
+      POST: 1
+      NETWORKS: 1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  router:
+    depends_on:
+      - socket-proxy
+    image: itzg/mc-router
+    environment:
+      IN_DOCKER: true
+      DOCKER_SOCKET: "tcp://socket-proxy:2375"
+      AUTO_SCALE_DOWN: true
+      AUTO_SCALE_UP: true
+      AUTO_SCALE_DOWN_AFTER: 1m
+      AUTO_SCALE_ASLEEP_MOTD: "Server is asleep. Join again to wake it up!"
+      DEBUG: true
+    ports:
+      - "25565:25565"
+
+  vanilla:
+    image: itzg/minecraft-server
+    environment:
+      EULA: "TRUE"
+    labels:
+      mc-router.host: "vanilla.example.com"
+  paper:
+    image: itzg/minecraft-server
+    environment:
+      EULA: "TRUE"
+      TYPE: PAPER
+    labels:
+      mc-router.host: "paper.example.com"
+

--- a/examples/docker-autoscale/compose-minimal.yml
+++ b/examples/docker-autoscale/compose-minimal.yml
@@ -11,6 +11,11 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    # If getting "Permission denied" errors for the docker socket
+    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
+    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
+    user: ":999"
+
   vanilla:
     image: itzg/minecraft-server
     environment:

--- a/examples/docker-autoscale/compose-minimal.yml
+++ b/examples/docker-autoscale/compose-minimal.yml
@@ -11,10 +11,9 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # If getting "Permission denied" errors for the docker socket
-    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
-    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
-    user: ":999"
+    # Refer to the "User access to docker socket" section in the README
+    group_add:
+      - "0"
 
   vanilla:
     image: itzg/minecraft-server

--- a/examples/docker-autoscale/compose.yml
+++ b/examples/docker-autoscale/compose.yml
@@ -20,6 +20,11 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    # If getting "Permission denied" errors for the docker socket
+    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
+    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
+    user: ":999"
+
   vanilla:
     image: itzg/minecraft-server
     environment:

--- a/examples/docker-autoscale/compose.yml
+++ b/examples/docker-autoscale/compose.yml
@@ -20,10 +20,9 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # If getting "Permission denied" errors for the docker socket
-    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
-    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
-    user: ":999"
+    # Refer to the "User access to docker socket" section in the README
+    group_add:
+      - "0"
 
   vanilla:
     image: itzg/minecraft-server

--- a/examples/docker-autoscale/compose.yml
+++ b/examples/docker-autoscale/compose.yml
@@ -1,5 +1,5 @@
 # This is a verbose example with comments and explanations for configuring auto-scaling behavior
-# for Docker backend servers. See compose.yml for a simple minimal example.
+# for Docker backend servers. See compose-minimal.yml for a simple minimal example.
 services:
   router:
     image: itzg/mc-router

--- a/examples/docker-autoscale/compose.yml
+++ b/examples/docker-autoscale/compose.yml
@@ -1,5 +1,5 @@
 # This is a verbose example with comments and explanations for configuring auto-scaling behavior
-# for Docker backend servers. See compose-minimal.yml for a simple minimal example.
+# for Docker backend servers. See compose.yml for a simple minimal example.
 services:
   router:
     image: itzg/mc-router

--- a/examples/docker-discovery-ipv6/compose.yml
+++ b/examples/docker-discovery-ipv6/compose.yml
@@ -20,10 +20,9 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # If getting "Permission denied" errors for the docker socket
-    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
-    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
-    user: ":999"
+    # Refer to the "User access to docker socket" section in the README
+    group_add:
+      - "0"
 
 networks:
   only-ipv6:

--- a/examples/docker-discovery-ipv6/compose.yml
+++ b/examples/docker-discovery-ipv6/compose.yml
@@ -20,6 +20,11 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    # If getting "Permission denied" errors for the docker socket
+    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
+    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
+    user: ":999"
+
 networks:
   only-ipv6:
     driver: bridge

--- a/examples/docker-discovery/compose.yml
+++ b/examples/docker-discovery/compose.yml
@@ -7,6 +7,10 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    # If getting "Permission denied" errors for the docker socket
+    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
+    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
+    user: ":999"
     # Matches MCs below
     network_mode: bridge
   vanilla:

--- a/examples/docker-discovery/compose.yml
+++ b/examples/docker-discovery/compose.yml
@@ -7,10 +7,9 @@ services:
       - "25565:25565"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # If getting "Permission denied" errors for the docker socket
-    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
-    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
-    user: ":999"
+    # Refer to the "User access to docker socket" section in the README
+    group_add:
+      - "0"
     # Matches MCs below
     network_mode: bridge
   vanilla:

--- a/examples/swarm/compose.yml
+++ b/examples/swarm/compose.yml
@@ -1,9 +1,22 @@
-version: '3.8'
-
 services:
+  # Isolate root-level access to the docker socket
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    user: root
+    environment:
+      CONTAINERS: 1
+      SERVICES: 1
+      NODES: 1
+      TASKS: 1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - minecraft
+
+  # ...to be used by other services such as mc-router
   router:
     image: itzg/mc-router:latest
-    command: --in-docker-swarm
+    command: --in-docker-swarm --docker-socket=tcp://socket-proxy:2375
     deploy:
       mode: replicated
       replicas: 1
@@ -11,12 +24,6 @@ services:
       - "25565:25565"
     networks:
       - minecraft
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    # If getting "Permission denied" errors for the docker socket
-    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
-    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
-    user: ":999"
 
   mcfoobar:
     image: itzg/minecraft-server:latest

--- a/examples/swarm/compose.yml
+++ b/examples/swarm/compose.yml
@@ -8,7 +8,6 @@ services:
       SERVICES: 1
       POST: 1
       NETWORKS: 1
-      NODES: 1
       TASKS: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/examples/swarm/compose.yml
+++ b/examples/swarm/compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       CONTAINERS: 1
       SERVICES: 1
+      POST: 1
+      NETWORKS: 1
       NODES: 1
       TASKS: 1
     volumes:
@@ -15,13 +17,22 @@ services:
 
   # ...to be used by other services such as mc-router
   router:
-    image: itzg/mc-router:latest
-    command: --in-docker-swarm --docker-socket=tcp://socket-proxy:2375
+    image: itzg/mc-router
+    environment:
+      IN_DOCKER_SWARM: "true"
+      DOCKER_SOCKET: "tcp://socket-proxy:2375"
+      AUTO_SCALE_DOWN: "true"
+      AUTO_SCALE_UP: "true"
+      AUTO_SCALE_DOWN_AFTER: "1m"
+      AUTO_SCALE_ASLEEP_MOTD: "Server is asleep. Join again to wake it up!"
     deploy:
       mode: replicated
       replicas: 1
     ports:
-      - "25565:25565"
+      - target: 25565
+        published: 25565
+        protocol: tcp
+        mode: host
     networks:
       - minecraft
 
@@ -33,7 +44,7 @@ services:
       mode: replicated
       replicas: 1
       labels:
-        - "mc-router.host=foo.host.name,bar.host.name"
+        - "mc-router.host=foo.host.name,bar.host.name,localhost"
         - "mc-router.network=minecraft" # not required in this case
     volumes:
       - mcfoobardata:/data

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/itzg/mc-router
 go 1.26.5
 
 require (
+	github.com/avast/retry-go/v5 v5.0.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-kit/kit v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
+github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/server/api_server.go
+++ b/server/api_server.go
@@ -57,7 +57,7 @@ func (a *apiServer) routesListHandler(writer http.ResponseWriter, _ *http.Reques
 	routes := make(map[string]serverRoute, len(mappings))
 	for k := range mappings {
 		backend, address, scalingTarget, _, _ := a.routes.FindBackendForServerAddress(context.Background(), k)
-		routes[address] = serverRoute{Backend: backend, ScalingTarget: scalingTarget}
+		routes[address] = serverRoute{Backend: backend, ScalingTarget: scalingTarget.String()}
 	}
 
 	bytes, err := json.Marshal(routes)
@@ -77,7 +77,7 @@ func (a *apiServer) routesListHandler(writer http.ResponseWriter, _ *http.Reques
 func (a *apiServer) routesDeleteHandler(writer http.ResponseWriter, request *http.Request) {
 	serverAddress := mux.Vars(request)["serverAddress"]
 	if serverAddress != "" {
-		if a.routes.DeleteMapping(serverAddress) {
+		if a.routes.RemoveMapping(serverAddress) {
 			writer.WriteHeader(http.StatusOK)
 		} else {
 			writer.WriteHeader(http.StatusNotFound)
@@ -103,8 +103,8 @@ func (a *apiServer) routesCreateHandler(writer http.ResponseWriter, request *htt
 		return
 	}
 
-	waker, sleeper := a.scaler.routeFuncs(definition.ServerAddress, definition.Backend)
-	a.routes.CreateMapping(definition.ServerAddress, definition.Backend, "", waker, sleeper, "", "")
+	waker, sleeper, scalingTarget := a.scaler.routeFuncs(definition.ServerAddress, definition.Backend)
+	a.routes.CreateMapping(definition.ServerAddress, definition.Backend, scalingTarget, waker, sleeper, "", "")
 	a.configLoader.SaveRoutes()
 	writer.WriteHeader(http.StatusCreated)
 }
@@ -125,8 +125,8 @@ func (a *apiServer) routesSetDefault(writer http.ResponseWriter, request *http.R
 		return
 	}
 
-	waker, sleeper := a.scaler.routeFuncs("", body.Backend)
-	a.routes.SetDefaultRoute(body.Backend, "", waker, sleeper, "", "")
+	waker, sleeper, scalingTarget := a.scaler.routeFuncs("", body.Backend)
+	a.routes.SetDefaultRoute(body.Backend, scalingTarget, waker, sleeper, "", "")
 	a.configLoader.SaveRoutes()
 	writer.WriteHeader(http.StatusOK)
 }

--- a/server/api_server.go
+++ b/server/api_server.go
@@ -57,7 +57,7 @@ func (a *apiServer) routesListHandler(writer http.ResponseWriter, _ *http.Reques
 	routes := make(map[string]serverRoute, len(mappings))
 	for k := range mappings {
 		backend, address, scalingTarget, _, _ := a.routes.FindBackendForServerAddress(context.Background(), k)
-		routes[address] = serverRoute{Backend: backend, ScalingTarget: scalingTarget.String()}
+		routes[address] = serverRoute{Backend: backend, ScalingTarget: scalingTarget.ScalingKey()}
 	}
 
 	bytes, err := json.Marshal(routes)

--- a/server/connector.go
+++ b/server/connector.go
@@ -42,6 +42,7 @@ var noDeadline time.Time
 
 type ActiveConnections struct {
 	sync.RWMutex
+	// activeConnections key is either a backend address or scaling target key depending on metrics usage
 	activeConnections map[string]int
 }
 
@@ -51,24 +52,24 @@ func NewActiveConnections() *ActiveConnections {
 	}
 }
 
-func (sm *ActiveConnections) Increment(backendAddress string) {
+func (sm *ActiveConnections) Increment(key string) {
 	sm.Lock()
 	defer sm.Unlock()
-	if _, ok := sm.activeConnections[backendAddress]; !ok {
-		sm.activeConnections[backendAddress] = 1
+	if _, ok := sm.activeConnections[key]; !ok {
+		sm.activeConnections[key] = 1
 		return
 	}
-	sm.activeConnections[backendAddress] += 1
+	sm.activeConnections[key] += 1
 }
 
-func (sm *ActiveConnections) Decrement(backendAddress string) {
+func (sm *ActiveConnections) Decrement(key string) {
 	sm.Lock()
 	defer sm.Unlock()
-	if activeConnections, ok := sm.activeConnections[backendAddress]; ok && activeConnections <= 0 {
-		sm.activeConnections[backendAddress] = 0
+	if activeConnections, ok := sm.activeConnections[key]; ok && activeConnections <= 0 {
+		sm.activeConnections[key] = 0
 		return
 	}
-	sm.activeConnections[backendAddress] -= 1
+	sm.activeConnections[key] -= 1
 }
 
 func (sm *ActiveConnections) GetCount(backendAddress string) int {
@@ -533,7 +534,7 @@ func sanitizeUTF8(s string) string {
 	return strings.ToValidUTF8(s, "")
 }
 
-func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress string, playerInfo *PlayerInfo, backendHostPort string, scalingTarget string, cleanupMetrics bool, checkScaleDown bool) {
+func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress string, playerInfo *PlayerInfo, backendHostPort string, scalingTarget ScalingTarget, cleanupMetrics bool, checkScaleDown bool) {
 	if c.connectionNotifier != nil {
 		err := c.connectionNotifier.NotifyDisconnected(c.ctx, clientAddr, serverAddress, playerInfo, backendHostPort)
 		if err != nil {
@@ -550,7 +551,9 @@ func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress 
 			With("server_address", sanitizeUTF8(serverAddress)).
 			Set(float64(c.activeConnections.GetCount(backendHostPort)))
 
-		c.scaleActiveConnections.Decrement(scalingTarget)
+		if scalingTarget != nil {
+			c.scaleActiveConnections.Decrement(scalingTarget.Key())
+		}
 
 		if c.recordLogins && playerInfo != nil {
 			c.metrics.ServerActivePlayer.
@@ -566,7 +569,7 @@ func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress 
 		WithField("player", playerInfo).
 		WithField("connectionCount", c.activeConnections.GetCount(backendHostPort)).
 		Info("Closed connection to backend")
-	if checkScaleDown && c.scaleActiveConnections.GetCount(scalingTarget) <= 0 {
+	if checkScaleDown && scalingTarget != nil && c.scaleActiveConnections.GetCount(scalingTarget.Key()) <= 0 {
 		c.downScaler.Start(c.ctx, scalingTarget, c.routes)
 	}
 	c.connectionsCond.Signal()
@@ -593,10 +596,10 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			Debug("checked if player is allowed to wake up the server")
 		if serverAllowsPlayer {
 			// Cancel down scaler if active before scale up
-			if scalingTarget != "" {
+			if scalingTarget != nil {
 				c.downScaler.Cancel(scalingTarget)
+				cleanupCheckScaleDown = true
 			}
-			cleanupCheckScaleDown = true
 			logrus.WithField("serverAddress", serverAddress).Info("Waking up backend server")
 			c.wakingServers.Increment(serverAddress)
 			newBackendHostPort, err := waker(c.ctx)
@@ -611,11 +614,6 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 				c.metrics.Errors.With("type", "wakeup_no_address").Add(1)
 				return
 			}
-			if scalingTarget == "" {
-				scalingTarget = newBackendHostPort
-			}
-			// Cancel again in case any routes were changed during wake up
-			c.downScaler.Cancel(scalingTarget)
 			backendHostPort = newBackendHostPort
 			logrus.WithFields(logrus.Fields{
 				"serverAddress":   serverAddress,
@@ -729,7 +727,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 		atomic.AddInt32(&c.totalActiveConnections, 1)))
 
 	c.activeConnections.Increment(backendHostPort)
-	c.scaleActiveConnections.Increment(scalingTarget)
+	c.scaleActiveConnections.Increment(scalingTarget.Key())
 	c.metrics.ServerActiveConnections.
 		With("server_address", sanitizeUTF8(serverAddress)).
 		Set(float64(c.activeConnections.GetCount(backendHostPort)))

--- a/server/connector.go
+++ b/server/connector.go
@@ -621,7 +621,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			// immediately schedule a scale-down — the server was just started. The
 			// scale-down timer is only armed below once a connection is established.
 
-			logrus.WithField("serverAddress", serverAddress).Info("Waking up backend server")
+			logrus.WithField("serverAddress", serverAddress).Info("Scaling up backend server")
 			c.wakingServers.Increment(serverAddress)
 			newBackendHostPort, err := waker(c.ctx)
 			c.wakingServers.Decrement(serverAddress)

--- a/server/connector.go
+++ b/server/connector.go
@@ -552,7 +552,7 @@ func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress 
 			Set(float64(c.activeConnections.GetCount(backendHostPort)))
 
 		if scalingTarget != nil {
-			c.scaleActiveConnections.Decrement(scalingTarget.Key())
+			c.scaleActiveConnections.Decrement(scalingTarget.ScalingKey())
 		}
 
 		if c.recordLogins && playerInfo != nil {
@@ -569,7 +569,7 @@ func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress 
 		WithField("player", playerInfo).
 		WithField("connectionCount", c.activeConnections.GetCount(backendHostPort)).
 		Info("Closed connection to backend")
-	if checkScaleDown && scalingTarget != nil && c.scaleActiveConnections.GetCount(scalingTarget.Key()) <= 0 {
+	if checkScaleDown && scalingTarget != nil && c.scaleActiveConnections.GetCount(scalingTarget.ScalingKey()) <= 0 {
 		c.downScaler.Start(c.ctx, scalingTarget, c.routes)
 	}
 	c.connectionsCond.Signal()
@@ -594,12 +594,13 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			WithField("player", playerInfo).
 			WithField("serverAllowsPlayer", serverAllowsPlayer).
 			Debug("checked if player is allowed to wake up the server")
-		if serverAllowsPlayer {
+		if serverAllowsPlayer && scalingTarget.StartScaling() {
+			defer scalingTarget.EndScaling()
+
 			// Cancel down scaler if active before scale up
-			if scalingTarget != nil {
-				c.downScaler.Cancel(scalingTarget)
-				cleanupCheckScaleDown = true
-			}
+			c.downScaler.Cancel(scalingTarget)
+			cleanupCheckScaleDown = true
+
 			logrus.WithField("serverAddress", serverAddress).Info("Waking up backend server")
 			c.wakingServers.Increment(serverAddress)
 			newBackendHostPort, err := waker(c.ctx)
@@ -727,7 +728,9 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 		atomic.AddInt32(&c.totalActiveConnections, 1)))
 
 	c.activeConnections.Increment(backendHostPort)
-	c.scaleActiveConnections.Increment(scalingTarget.Key())
+	if scalingTarget != nil {
+		c.scaleActiveConnections.Increment(scalingTarget.ScalingKey())
+	}
 	c.metrics.ServerActiveConnections.
 		With("server_address", sanitizeUTF8(serverAddress)).
 		Set(float64(c.activeConnections.GetCount(backendHostPort)))

--- a/server/connector.go
+++ b/server/connector.go
@@ -628,7 +628,9 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			// immediately schedule a scale-down — the server was just started. The
 			// scale-down timer is only armed below once a connection is established.
 
-			logrus.WithField("serverAddress", serverAddress).Info("Scaling up backend server")
+			logrus.WithField("serverAddress", serverAddress).
+				WithField("scalingTarget", scalingTarget).
+				Info("Scaling up backend server")
 			c.wakingServers.Increment(serverAddress)
 			newBackendHostPort, err := waker(c.ctx)
 			c.wakingServers.Decrement(serverAddress)

--- a/server/connector.go
+++ b/server/connector.go
@@ -578,8 +578,14 @@ func (c *Connector) cleanupBackendConnection(
 		WithField("player", playerInfo).
 		WithField("connectionCount", c.activeConnections.GetCount(backendHostPort)).
 		Info("Closed connection to backend")
-	if checkScaleDown && scalingTarget != nil && c.downScaler != nil && c.scaleActiveConnections.GetCount(scalingTarget.ScalingKey()) <= 0 {
-		c.downScaler.Start(c.ctx, scalingTarget, c.routes)
+	if scalingTarget != nil && checkScaleDown {
+		scaleCount := c.scaleActiveConnections.GetCount(scalingTarget.ScalingKey())
+		logrus.WithField("scalingTarget", scalingTarget).
+			WithField("scaleActiveConnections", scaleCount).
+			Debug("Evaluating scale-down after connection close")
+		if c.downScaler != nil && scaleCount <= 0 {
+			c.downScaler.Start(c.ctx, scalingTarget, c.routes)
+		}
 	}
 	c.connectionsCond.Signal()
 }
@@ -610,7 +616,10 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			if c.downScaler != nil {
 				c.downScaler.Cancel(scalingTarget)
 			}
-			cleanupCheckScaleDown = true
+			// Note: cleanupCheckScaleDown is intentionally NOT set here. If the dial
+			// fails after a successful wake (backend still booting), we must not
+			// immediately schedule a scale-down — the server was just started. The
+			// scale-down timer is only armed below once a connection is established.
 
 			logrus.WithField("serverAddress", serverAddress).Info("Waking up backend server")
 			c.wakingServers.Increment(serverAddress)
@@ -700,6 +709,12 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			WithField("player", playerInfo).
 			Warn("Unable to connect to backend")
 		c.metrics.Errors.With("type", "backend_failed").Add(1)
+
+		if waker != nil {
+			logrus.WithField("serverAddress", serverAddress).
+				WithField("backend", backendHostPort).
+				Debug("Backend not ready after wake; scale-down timer will not be started")
+		}
 
 		if c.connectionNotifier != nil {
 			notifyErr := c.connectionNotifier.NotifyFailedBackendConnection(c.ctx, clientAddr, serverAddress, playerInfo, backendHostPort, err)

--- a/server/connector.go
+++ b/server/connector.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/avast/retry-go/v5"
 	"golang.ngrok.com/ngrok"
 	"golang.ngrok.com/ngrok/config"
 
@@ -36,6 +37,12 @@ const (
 	// reachable faster (e.g. on-cluster Services) can lower it so the asleep
 	// MOTD / scale-up fallback fires sooner.
 	defaultBackendDialTimeout = 2 * time.Second
+)
+
+const (
+	backendReadyRetryDelay     = 500 * time.Millisecond
+	backendReadyConnectTimeout = 250 * time.Millisecond
+	backendReadyRetryMaxDelay  = 1 * time.Second
 )
 
 var noDeadline time.Time
@@ -960,4 +967,41 @@ func protocolToName(proto int) string {
 	default:
 		return "1.7+"
 	}
+}
+
+func waitForBackend(ctx context.Context, endpoint string, waitTimeout time.Duration) (string, error) {
+	// Apply overall deadline to retries
+	retryCtx, retryCancel := context.WithTimeout(ctx, waitTimeout)
+	defer retryCancel()
+
+	retryErr := retry.New(
+		retry.Context(retryCtx),
+		retry.DelayType(retry.BackOffDelay),
+		retry.Delay(backendReadyRetryDelay),
+		retry.MaxDelay(backendReadyRetryMaxDelay),
+		retry.UntilSucceeded(),
+		retry.OnRetry(func(n uint, err error) {
+			logrus.
+				WithField("endpoint", endpoint).
+				WithField("attempt", n).
+				WithError(err).
+				Debug("Retrying K8s backend reachability")
+		}),
+	).Do(func() error {
+		conn, err := net.DialTimeout("tcp", endpoint, backendReadyConnectTimeout)
+		if err == nil {
+			_ = conn.Close()
+			logrus.WithField("endpoint", endpoint).Debug("K8s backend is now reachable")
+			return nil
+		}
+		return err
+	})
+	if errors.Is(retryErr, context.DeadlineExceeded) {
+		return endpoint, fmt.Errorf("timeout waiting for K8s backend to become reachable at %s", endpoint)
+	} else if retryErr != nil {
+		return endpoint, fmt.Errorf("error waiting for K8s backend to become reachable at %s: %w", endpoint, retryErr)
+	}
+
+	return endpoint, nil
+
 }

--- a/server/connector.go
+++ b/server/connector.go
@@ -116,9 +116,10 @@ type NgrokConnector struct {
 }
 
 type Connector struct {
-	ctx                        context.Context
-	state                      mcproto.State
-	routes                     IRoutes
+	ctx    context.Context
+	state  mcproto.State
+	routes IRoutes
+	// downScaler is used to scale up and down the number of backend connections. nil if disabled.
 	downScaler                 IDownScaler
 	metrics                    *ConnectorMetrics
 	sendProxyProto             bool
@@ -534,7 +535,15 @@ func sanitizeUTF8(s string) string {
 	return strings.ToValidUTF8(s, "")
 }
 
-func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress string, playerInfo *PlayerInfo, backendHostPort string, scalingTarget ScalingTarget, cleanupMetrics bool, checkScaleDown bool) {
+func (c *Connector) cleanupBackendConnection(
+	clientAddr net.Addr,
+	serverAddress string,
+	playerInfo *PlayerInfo,
+	backendHostPort string,
+	scalingTarget ScalingTarget,
+	cleanupMetrics bool,
+	checkScaleDown bool,
+) {
 	if c.connectionNotifier != nil {
 		err := c.connectionNotifier.NotifyDisconnected(c.ctx, clientAddr, serverAddress, playerInfo, backendHostPort)
 		if err != nil {
@@ -569,7 +578,7 @@ func (c *Connector) cleanupBackendConnection(clientAddr net.Addr, serverAddress 
 		WithField("player", playerInfo).
 		WithField("connectionCount", c.activeConnections.GetCount(backendHostPort)).
 		Info("Closed connection to backend")
-	if checkScaleDown && scalingTarget != nil && c.scaleActiveConnections.GetCount(scalingTarget.ScalingKey()) <= 0 {
+	if checkScaleDown && scalingTarget != nil && c.downScaler != nil && c.scaleActiveConnections.GetCount(scalingTarget.ScalingKey()) <= 0 {
 		c.downScaler.Start(c.ctx, scalingTarget, c.routes)
 	}
 	c.connectionsCond.Signal()
@@ -598,7 +607,9 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			defer scalingTarget.EndScaling()
 
 			// Cancel down scaler if active before scale up
-			c.downScaler.Cancel(scalingTarget)
+			if c.downScaler != nil {
+				c.downScaler.Cancel(scalingTarget)
+			}
 			cleanupCheckScaleDown = true
 
 			logrus.WithField("serverAddress", serverAddress).Info("Waking up backend server")
@@ -730,6 +741,14 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 	c.activeConnections.Increment(backendHostPort)
 	if scalingTarget != nil {
 		c.scaleActiveConnections.Increment(scalingTarget.ScalingKey())
+		// Cancel any pending scale-down timer — the Docker event that fires during
+		// wake-up may have started a new timer after our pre-wake Cancel call.
+		// Also covers status pings: they cancel the timer here, and cleanupCheckScaleDown
+		// ensures the timer is restarted when the ping connection closes.
+		if c.downScaler != nil {
+			c.downScaler.Cancel(scalingTarget)
+			cleanupCheckScaleDown = true
+		}
 	}
 	c.metrics.ServerActiveConnections.
 		With("server_address", sanitizeUTF8(serverAddress)).

--- a/server/connector_test.go
+++ b/server/connector_test.go
@@ -141,8 +141,9 @@ func TestConnectorMOTDFallback(t *testing.T) {
 		scaleUpCalled = true
 		return backendAddress, nil
 	}
+	scalingTarget := TestingScalingTarget(backendAddress)
 
-	routes.CreateMapping("mc.example.com", backendAddress, nil, waker, nil, "fallback asleep", "fallback loading")
+	routes.CreateMapping("mc.example.com", backendAddress, scalingTarget, waker, nil, "fallback asleep", "fallback loading")
 
 	metricsBuilder := discardMetricsBuilder{}
 	c := NewConnector(t.Context(), routes, downScaler, metricsBuilder.BuildConnectorMetrics(), false, false, nil)

--- a/server/connector_test.go
+++ b/server/connector_test.go
@@ -103,7 +103,7 @@ func TestConnectorWakeTracking(t *testing.T) {
 
 func TestConnectorGetLoadingMOTD(t *testing.T) {
 	routes := NewRoutes(t.Context())
-	routes.CreateMapping("mc.example.com", "backend:25565", "", nil, nil, "",
+	routes.CreateMapping("mc.example.com", "backend:25565", nil, nil, nil, "",
 		"route loading")
 
 	c := NewConnector(t.Context(), routes, NewDownScaler(false, 5*time.Second), discardMetricsBuilder{}.BuildConnectorMetrics(), false, false, nil)
@@ -111,7 +111,7 @@ func TestConnectorGetLoadingMOTD(t *testing.T) {
 	assert.Equal(t, "route loading", c.getLoadingMOTD("mc.example.com"))
 	assert.Equal(t, "global loading", c.getLoadingMOTD("other.example.com"))
 
-	routes.SetDefaultRoute("default:25565", "", nil, nil, "", "default loading")
+	routes.SetDefaultRoute("default:25565", nil, nil, nil, "", "default loading")
 	assert.Equal(t, "default loading", c.getLoadingMOTD(""))
 }
 
@@ -142,7 +142,7 @@ func TestConnectorMOTDFallback(t *testing.T) {
 		return backendAddress, nil
 	}
 
-	routes.CreateMapping("mc.example.com", backendAddress, "", waker, nil, "fallback asleep", "fallback loading")
+	routes.CreateMapping("mc.example.com", backendAddress, nil, waker, nil, "fallback asleep", "fallback loading")
 
 	metricsBuilder := discardMetricsBuilder{}
 	c := NewConnector(t.Context(), routes, downScaler, metricsBuilder.BuildConnectorMetrics(), false, false, nil)
@@ -221,4 +221,3 @@ func TestConnectorNonUTF8Handshake(t *testing.T) {
 	buf := make([]byte, 10)
 	_, _ = clientConn.Read(buf)
 }
-

--- a/server/docker.go
+++ b/server/docker.go
@@ -731,7 +731,7 @@ func (t *DockerScalingTarget) String() string {
 	if t == nil {
 		return ""
 	}
-	return t.containerId
+	return "docker{" + t.containerId + "}"
 }
 
 func (t *DockerScalingTarget) ScalingKey() string {

--- a/server/docker.go
+++ b/server/docker.go
@@ -279,26 +279,26 @@ func (w *dockerWatcherImpl) containersForID(ctx context.Context, containerId str
 	scalingTarget := NewDockerScalingTarget(containerId)
 	for _, host := range data.hosts {
 		result = append(result, &routableContainer{
-			containerEndpoint:     endpoint,
-			externalContainerName: host,
-			containerId:           containerId,
-			autoScaleUp:           data.autoScaleUp,
-			autoScaleDown:         data.autoScaleDown,
-			autoScaleAsleepMOTD:   data.autoScaleAsleepMOTD,
-			autoScaleLoadingMOTD:  data.autoScaleLoadingMOTD,
-			scalingTarget:         scalingTarget,
+			containerEndpoint:    endpoint,
+			externalName:         host,
+			containerId:          containerId,
+			autoScaleUp:          data.autoScaleUp,
+			autoScaleDown:        data.autoScaleDown,
+			autoScaleAsleepMOTD:  data.autoScaleAsleepMOTD,
+			autoScaleLoadingMOTD: data.autoScaleLoadingMOTD,
+			scalingTarget:        scalingTarget,
 		})
 	}
 	if data.def != nil && *data.def {
 		result = append(result, &routableContainer{
-			containerEndpoint:     endpoint,
-			externalContainerName: "",
-			containerId:           containerId,
-			autoScaleUp:           data.autoScaleUp,
-			autoScaleDown:         data.autoScaleDown,
-			autoScaleAsleepMOTD:   data.autoScaleAsleepMOTD,
-			autoScaleLoadingMOTD:  data.autoScaleLoadingMOTD,
-			scalingTarget:         scalingTarget,
+			containerEndpoint:    endpoint,
+			externalName:         "",
+			containerId:          containerId,
+			autoScaleUp:          data.autoScaleUp,
+			autoScaleDown:        data.autoScaleDown,
+			autoScaleAsleepMOTD:  data.autoScaleAsleepMOTD,
+			autoScaleLoadingMOTD: data.autoScaleLoadingMOTD,
+			scalingTarget:        scalingTarget,
 		})
 	}
 	return result, nil
@@ -309,7 +309,7 @@ func (w *dockerWatcherImpl) containersForID(ctx context.Context, containerId str
 func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerId string, desired []*routableContainer) {
 	desiredByName := map[string]*routableContainer{}
 	for _, rc := range desired {
-		desiredByName[rc.externalContainerName] = rc
+		desiredByName[rc.externalName] = rc
 	}
 
 	// Drop entries previously owned by this container that are no longer desired
@@ -330,13 +330,13 @@ func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerId string, desir
 	}
 
 	for _, rs := range desired {
-		oldRs, exists := w.containerMap[rs.externalContainerName]
+		oldRs, exists := w.containerMap[rs.externalName]
 		if !exists {
-			w.containerMap[rs.externalContainerName] = rs
+			w.containerMap[rs.externalName] = rs
 			wakerFunc := w.makeWakerFunc(rs)
 			sleeperFunc := w.makeSleeperFunc(rs)
-			if rs.externalContainerName != "" {
-				w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+			if rs.externalName != "" {
+				w.routes.CreateMapping(rs.externalName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			} else {
 				w.routes.SetDefaultRoute(rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			}
@@ -351,12 +351,11 @@ func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerId string, desir
 			oldRs.autoScaleLoadingMOTD == rs.autoScaleLoadingMOTD {
 			continue
 		}
-		w.containerMap[rs.externalContainerName] = rs
+		w.containerMap[rs.externalName] = rs
 		wakerFunc := w.makeWakerFunc(rs)
 		sleeperFunc := w.makeSleeperFunc(rs)
-		if rs.externalContainerName != "" {
-			w.routes.RemoveMapping(rs.externalContainerName)
-			w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+		if rs.externalName != "" {
+			w.routes.UpdateMapping(rs.externalName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 		} else {
 			w.routes.SetDefaultRoute(rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 		}
@@ -513,14 +512,14 @@ func (w *dockerWatcherImpl) listContainers(ctx context.Context) ([]*routableCont
 
 func newRoutableContainer(endpoint string, host string, containerId string, data parsedDockerContainerData, target *DockerScalingTarget) *routableContainer {
 	return &routableContainer{
-		containerEndpoint:     endpoint,
-		externalContainerName: host,
-		containerId:           containerId,
-		autoScaleUp:           data.autoScaleUp,
-		autoScaleDown:         data.autoScaleDown,
-		autoScaleAsleepMOTD:   data.autoScaleAsleepMOTD,
-		autoScaleLoadingMOTD:  data.autoScaleLoadingMOTD,
-		scalingTarget:         target,
+		containerEndpoint:    endpoint,
+		externalName:         host,
+		containerId:          containerId,
+		autoScaleUp:          data.autoScaleUp,
+		autoScaleDown:        data.autoScaleDown,
+		autoScaleAsleepMOTD:  data.autoScaleAsleepMOTD,
+		autoScaleLoadingMOTD: data.autoScaleLoadingMOTD,
+		scalingTarget:        target,
 	}
 }
 
@@ -701,14 +700,19 @@ func (w *dockerWatcherImpl) parseContainerData(container *container.InspectRespo
 
 type routableContainer struct {
 	ScalingIndicator
-	externalContainerName string
-	containerEndpoint     string
-	containerId           string
-	autoScaleUp           bool
-	autoScaleDown         bool
-	autoScaleAsleepMOTD   string
-	autoScaleLoadingMOTD  string
-	scalingTarget         *DockerScalingTarget
+	externalName         string
+	containerEndpoint    string
+	containerId          string
+	autoScaleUp          bool
+	autoScaleDown        bool
+	autoScaleAsleepMOTD  string
+	autoScaleLoadingMOTD string
+	scalingTarget        *DockerScalingTarget
+}
+
+func (r *routableContainer) String() string {
+	return fmt.Sprintf("routableContainer{externalName=%s, endpoint=%s, id=%s, autoScaleUp=%t, autoScaleDown=%t, autoScaleAsleepMOTD=%s, autoScaleLoadingMOTD=%s, scalingTarget=%v}",
+		r.externalName, r.containerEndpoint, r.containerId, r.autoScaleUp, r.autoScaleDown, r.autoScaleAsleepMOTD, r.autoScaleLoadingMOTD, r.scalingTarget)
 }
 
 type DockerScalingTarget struct {

--- a/server/docker.go
+++ b/server/docker.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -23,18 +24,18 @@ type IDockerWatcher interface {
 }
 
 const (
-	DockerRouterLabelHost                 = "mc-router.host"
-	DockerRouterLabelPort                 = "mc-router.port"
-	DockerRouterLabelDefault              = "mc-router.default"
-	DockerRouterLabelNetwork              = "mc-router.network"
-	DockerRouterLabelAutoScaleUp          = "mc-router.auto-scale-up"
-	DockerRouterLabelAutoScaleDown        = "mc-router.auto-scale-down"
-	DockerRouterLabelAutoScaleAsleepMOTD  = "mc-router.auto-scale-asleep-motd"
-	DockerRouterLabelAutoScaleLoadingMOTD = "mc-router.auto-scale-loading-motd"
-	DockerRouterLabelAutoScaleWaitTimeout = "mc-router.auto-scale-wait-timeout"
-	DockerRouterLabelAutoScaleFailedMOTD  = "mc-router.auto-scale-failed-motd"
+	DockerRouterLabelHost                      = "mc-router.host"
+	DockerRouterLabelPort                      = "mc-router.port"
+	DockerRouterLabelDefault                   = "mc-router.default"
+	DockerRouterLabelNetwork                   = "mc-router.network"
+	DockerRouterLabelAutoScaleUp               = "mc-router.auto-scale-up"
+	DockerRouterLabelAutoScaleDown             = "mc-router.auto-scale-down"
+	DockerRouterLabelAutoScaleAsleepMOTD       = "mc-router.auto-scale-asleep-motd"
+	DockerRouterLabelAutoScaleLoadingMOTD      = "mc-router.auto-scale-loading-motd"
+	DockerRouterLabelAutoScaleWaitTimeout      = "mc-router.auto-scale-wait-timeout"
+	DockerRouterLabelAutoScaleFailedMOTD       = "mc-router.auto-scale-failed-motd"
 	DockerRouterLabelAutoScaleRestartDelayMOTD = "mc-router.auto-scale-restart-delay-motd"
-	DockerRouterEventTypeTask             = "task"
+	DockerRouterEventTypeTask                  = "task"
 )
 
 type dockerWatcherConfig struct {
@@ -204,9 +205,9 @@ func (w *dockerWatcherImpl) monitorContainers(ctx context.Context) error {
 		}
 		delete(w.containerMap, name)
 		if name != "" {
-			w.routes.DeleteMapping(name)
+			w.routes.RemoveMapping(name)
 		} else {
-			w.routes.SetDefaultRoute("", "", nil, nil, "", "")
+			w.routes.RemoveDefaultRoute()
 		}
 		logrus.WithField("routableContainer", rc).Debug("DELETE")
 	}
@@ -318,23 +319,24 @@ func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerID string, desir
 		}
 		delete(w.containerMap, name)
 		if name != "" {
-			w.routes.DeleteMapping(name)
+			w.routes.RemoveMapping(name)
 		} else {
-			w.routes.SetDefaultRoute("", "", nil, nil, "", "")
+			w.routes.RemoveDefaultRoute()
 		}
 		logrus.WithField("routableContainer", rc).Debug("DELETE")
 	}
 
 	for _, rs := range desired {
+		scalingTarget := NewDockerScalingTarget(rs.containerID)
 		oldRs, exists := w.containerMap[rs.externalContainerName]
 		if !exists {
 			w.containerMap[rs.externalContainerName] = rs
 			wakerFunc := w.makeWakerFunc(rs)
 			sleeperFunc := w.makeSleeperFunc(rs)
 			if rs.externalContainerName != "" {
-				w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, "", wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, NamedScalingTarget(rs.containerID), wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			} else {
-				w.routes.SetDefaultRoute(rs.containerEndpoint, "", wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.SetDefaultRoute(rs.containerEndpoint, NamedScalingTarget(rs.containerID), wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			}
 			logrus.WithField("routableContainer", rs).Debug("ADD")
 			continue
@@ -351,10 +353,10 @@ func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerID string, desir
 		wakerFunc := w.makeWakerFunc(rs)
 		sleeperFunc := w.makeSleeperFunc(rs)
 		if rs.externalContainerName != "" {
-			w.routes.DeleteMapping(rs.externalContainerName)
-			w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, "", wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+			w.routes.RemoveMapping(rs.externalContainerName)
+			w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 		} else {
-			w.routes.SetDefaultRoute(rs.containerEndpoint, "", wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+			w.routes.SetDefaultRoute(rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 		}
 		logrus.WithFields(logrus.Fields{"old": oldRs, "new": rs}).Debug("UPDATE")
 	}
@@ -699,6 +701,7 @@ func (w *dockerWatcherImpl) parseContainerData(container *container.InspectRespo
 	return
 }
 
+// TODO have routableContainer implement ScalingTarget
 type routableContainer struct {
 	externalContainerName string
 	containerEndpoint     string
@@ -707,4 +710,41 @@ type routableContainer struct {
 	autoScaleDown         bool
 	autoScaleAsleepMOTD   string
 	autoScaleLoadingMOTD  string
+}
+
+type DockerScalingTarget struct {
+	ScalingIndicator
+	containerID string
+}
+
+func NewDockerScalingTarget(containerID string) *DockerScalingTarget {
+	return &DockerScalingTarget{
+		ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}},
+		containerID:      containerID,
+	}
+}
+
+func (t *DockerScalingTarget) String() string {
+	if t == nil {
+		return ""
+	}
+	return t.containerID
+}
+
+func (t *DockerScalingTarget) Equal(other ScalingTarget) bool {
+	if t == nil || other == nil {
+		return t == nil && other == nil
+	}
+	otherTarget, ok := other.(*DockerScalingTarget)
+	if !ok {
+		return false
+	}
+	return t.Key() == otherTarget.Key()
+}
+
+func (t *DockerScalingTarget) Key() string {
+	if t == nil {
+		return ""
+	}
+	return t.containerID
 }

--- a/server/docker.go
+++ b/server/docker.go
@@ -38,6 +38,8 @@ const (
 	DockerRouterLabelAutoScaleRestartDelayMOTD = "mc-router.auto-scale-restart-delay-motd"
 )
 
+const containerIdLen = 12
+
 type dockerWatcherConfig struct {
 	autoScaleUp   bool
 	autoScaleDown bool
@@ -276,7 +278,7 @@ func (w *dockerWatcherImpl) containersForID(ctx context.Context, containerId str
 		endpoint = dockerBackendEndpoint(data.ip, data.port)
 	}
 	var result []*routableContainer
-	scalingTarget := NewDockerScalingTarget(containerId)
+	scalingTarget := NewDockerScalingTarget(containerId, data.name)
 	for _, host := range data.hosts {
 		result = append(result, &routableContainer{
 			containerEndpoint:    endpoint,
@@ -495,10 +497,10 @@ func (w *dockerWatcherImpl) listContainers(ctx context.Context) ([]*routableCont
 			endpoint = dockerBackendEndpoint(data.ip, data.port)
 		}
 		logrus.WithField("backendEndpoint", endpoint).
-			WithField("containerId", containerId).
+			WithField("containerId", shortContainerId(containerId)).
 			Debug("Found routable Docker container")
 
-		scalingTarget := NewDockerScalingTarget(containerId)
+		scalingTarget := NewDockerScalingTarget(containerId, data.name)
 		for _, host := range data.hosts {
 			result = append(result, newRoutableContainer(endpoint, host, containerId, data, scalingTarget))
 		}
@@ -524,6 +526,7 @@ func newRoutableContainer(endpoint string, host string, containerId string, data
 }
 
 type parsedDockerContainerData struct {
+	name                 string
 	hosts                []string
 	port                 uint64
 	def                  *bool
@@ -553,6 +556,7 @@ func dockerBackendEndpoint(ip string, port uint64) string {
 func (w *dockerWatcherImpl) parseContainerData(container *container.InspectResponse) (data parsedDockerContainerData, ok bool) {
 	data.autoScaleUp = w.config.autoScaleUp
 	data.autoScaleDown = w.config.autoScaleDown
+	data.name = container.Name
 	for key, value := range container.Config.Labels {
 		if key == DockerRouterLabelHost {
 			if data.hosts != nil {
@@ -712,18 +716,24 @@ type routableContainer struct {
 
 func (r *routableContainer) String() string {
 	return fmt.Sprintf("routableContainer{externalName=%s, endpoint=%s, id=%s, autoScaleUp=%t, autoScaleDown=%t, autoScaleAsleepMOTD=%s, autoScaleLoadingMOTD=%s, scalingTarget=%v}",
-		r.externalName, r.containerEndpoint, r.containerId, r.autoScaleUp, r.autoScaleDown, r.autoScaleAsleepMOTD, r.autoScaleLoadingMOTD, r.scalingTarget)
+		r.externalName, r.containerEndpoint, shortContainerId(r.containerId), r.autoScaleUp, r.autoScaleDown, r.autoScaleAsleepMOTD, r.autoScaleLoadingMOTD, r.scalingTarget)
+}
+
+func shortContainerId(containerId string) string {
+	return containerId[0:containerIdLen]
 }
 
 type DockerScalingTarget struct {
 	ScalingIndicator
 	containerId string
+	name        string
 }
 
-func NewDockerScalingTarget(containerId string) *DockerScalingTarget {
+func NewDockerScalingTarget(containerId, name string) *DockerScalingTarget {
 	return &DockerScalingTarget{
 		ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}},
 		containerId:      containerId,
+		name:             name,
 	}
 }
 
@@ -731,7 +741,7 @@ func (t *DockerScalingTarget) String() string {
 	if t == nil {
 		return ""
 	}
-	return "docker{" + t.containerId + "}"
+	return fmt.Sprintf("docker{containerId=%s, name=%s}", shortContainerId(t.containerId), t.name)
 }
 
 func (t *DockerScalingTarget) ScalingKey() string {

--- a/server/docker.go
+++ b/server/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,7 +36,6 @@ const (
 	DockerRouterLabelAutoScaleWaitTimeout      = "mc-router.auto-scale-wait-timeout"
 	DockerRouterLabelAutoScaleFailedMOTD       = "mc-router.auto-scale-failed-motd"
 	DockerRouterLabelAutoScaleRestartDelayMOTD = "mc-router.auto-scale-restart-delay-motd"
-	DockerRouterEventTypeTask                  = "task"
 )
 
 type dockerWatcherConfig struct {
@@ -51,10 +51,10 @@ func (c *dockerWatcherConfig) apiVersionOpt() client.Opt {
 	if c.apiVersion != "" {
 		logrus.WithField("apiVersion", c.apiVersion).Debug("Using specific Docker API version")
 		return client.WithVersion(c.apiVersion)
-	} else {
-		logrus.Debug("Using Docker API version negotiation")
-		return client.WithAPIVersionNegotiation()
 	}
+
+	logrus.Debug("Using Docker API version negotiation")
+	return client.WithAPIVersionNegotiation()
 }
 
 func NewDockerWatcher(socket string, timeout time.Duration, autoScaleUp bool, autoScaleDown bool, dockerApiVersion string, routes IRoutes) IDockerWatcher {
@@ -84,11 +84,11 @@ func (w *dockerWatcherImpl) makeWakerFunc(rc *routableContainer) WakerFunc {
 		return nil
 	}
 	return func(ctx context.Context) (string, error) {
-		containerID := rc.containerID
-		if containerID == "" {
+		containerId := rc.containerId
+		if containerId == "" {
 			return "", fmt.Errorf("missing container id for wake")
 		}
-		inspect, err := w.client.ContainerInspect(ctx, containerID)
+		inspect, err := w.client.ContainerInspect(ctx, containerId)
 		if err != nil {
 			return "", err
 		}
@@ -97,18 +97,18 @@ func (w *dockerWatcherImpl) makeWakerFunc(rc *routableContainer) WakerFunc {
 		}
 		// If paused, unpause; if not running, start; otherwise no-op
 		if inspect.State.Paused {
-			logrus.WithFields(logrus.Fields{"containerID": containerID}).Debug("Unpausing container for wake")
-			if err := w.client.ContainerUnpause(ctx, containerID); err != nil {
+			logrus.WithFields(logrus.Fields{"containerId": containerId}).Debug("Unpausing container for wake")
+			if err := w.client.ContainerUnpause(ctx, containerId); err != nil {
 				return "", err
 			}
 		} else if !inspect.State.Running {
-			logrus.WithFields(logrus.Fields{"containerID": containerID}).Debug("Starting container for wake")
-			if err := w.client.ContainerStart(ctx, containerID, container.StartOptions{}); err != nil {
+			logrus.WithFields(logrus.Fields{"containerId": containerId}).Debug("Starting container for wake")
+			if err := w.client.ContainerStart(ctx, containerId, container.StartOptions{}); err != nil {
 				return "", err
 			}
 		}
 
-		inspect, err = w.client.ContainerInspect(ctx, containerID)
+		inspect, err = w.client.ContainerInspect(ctx, containerId)
 		if err != nil {
 			return "", err
 		}
@@ -153,19 +153,19 @@ func (w *dockerWatcherImpl) makeSleeperFunc(rc *routableContainer) SleeperFunc {
 		return nil
 	}
 	return func(ctx context.Context) error {
-		containerID := rc.containerID
-		if containerID == "" {
+		containerId := rc.containerId
+		if containerId == "" {
 			return fmt.Errorf("missing container id for sleep")
 		}
-		inspect, err := w.client.ContainerInspect(ctx, containerID)
+		inspect, err := w.client.ContainerInspect(ctx, containerId)
 		if err != nil {
 			return err
 		}
 		if inspect.State != nil && inspect.State.Running {
 			// Graceful stop with 60s timeout
 			timeout := 60
-			logrus.WithFields(logrus.Fields{"containerID": containerID}).Debug("Stopping container for sleep")
-			if err := w.client.ContainerStop(ctx, containerID, container.StopOptions{Timeout: &timeout}); err != nil {
+			logrus.WithFields(logrus.Fields{"containerId": containerId}).Debug("Stopping container for sleep")
+			if err := w.client.ContainerStop(ctx, containerId, container.StopOptions{Timeout: &timeout}); err != nil {
 				return err
 			}
 		}
@@ -191,7 +191,7 @@ func (w *dockerWatcherImpl) monitorContainers(ctx context.Context) error {
 
 	byID := map[string][]*routableContainer{}
 	for _, rc := range containers {
-		byID[rc.containerID] = append(byID[rc.containerID], rc)
+		byID[rc.containerId] = append(byID[rc.containerId], rc)
 	}
 
 	for id, desired := range byID {
@@ -200,7 +200,7 @@ func (w *dockerWatcherImpl) monitorContainers(ctx context.Context) error {
 
 	// Remove entries whose container is no longer present at all
 	for name, rc := range w.containerMap {
-		if _, present := byID[rc.containerID]; present {
+		if _, present := byID[rc.containerId]; present {
 			continue
 		}
 		delete(w.containerMap, name)
@@ -217,18 +217,18 @@ func (w *dockerWatcherImpl) monitorContainers(ctx context.Context) error {
 // applyEvent reacts to a single Docker event by reconciling only the routes
 // belonging to the affected container — no full re-list.
 func (w *dockerWatcherImpl) applyEvent(ctx context.Context, ev events.Message) error {
-	containerID := ev.Actor.ID
+	containerId := ev.Actor.ID
 	if ev.Type == events.NetworkEventType {
-		containerID = ev.Actor.Attributes["container"]
+		containerId = ev.Actor.Attributes["container"]
 	}
-	if containerID == "" {
+	if containerId == "" {
 		logrus.WithField("event", ev).Warn("network event missing container attribute, skipping")
 		return nil
 	}
 
 	var desired []*routableContainer
 	if !(ev.Type == events.ContainerEventType && ev.Action == events.ActionDestroy) {
-		got, err := w.containersForID(ctx, containerID)
+		got, err := w.containersForID(ctx, containerId)
 		if err != nil {
 			return err
 		}
@@ -243,24 +243,24 @@ func (w *dockerWatcherImpl) applyEvent(ctx context.Context, ev events.Message) e
 	relevant := len(desired) > 0
 	if !relevant {
 		for _, rc := range w.containerMap {
-			if rc.containerID == containerID {
+			if rc.containerId == containerId {
 				relevant = true
 				break
 			}
 		}
 	}
 	if relevant {
-		logrus.WithFields(logrus.Fields{"type": ev.Type, "action": ev.Action, "id": containerID}).Trace("Docker event")
+		logrus.WithFields(logrus.Fields{"type": ev.Type, "action": ev.Action, "id": containerId}).Trace("Docker event")
 	}
 
-	w.applyContainerRoutesLocked(containerID, desired)
+	w.applyContainerRoutesLocked(containerId, desired)
 	return nil
 }
 
 // containersForID inspects a single container and returns the routableContainers
 // it should produce. Returns nil if the container is gone or not routable.
-func (w *dockerWatcherImpl) containersForID(ctx context.Context, containerID string) ([]*routableContainer, error) {
-	inspect, err := w.client.ContainerInspect(ctx, containerID)
+func (w *dockerWatcherImpl) containersForID(ctx context.Context, containerId string) ([]*routableContainer, error) {
+	inspect, err := w.client.ContainerInspect(ctx, containerId)
 	if err != nil {
 		if cerrdefs.IsNotFound(err) {
 			return nil, nil
@@ -276,34 +276,37 @@ func (w *dockerWatcherImpl) containersForID(ctx context.Context, containerID str
 		endpoint = dockerBackendEndpoint(data.ip, data.port)
 	}
 	var result []*routableContainer
+	scalingTarget := NewDockerScalingTarget(containerId)
 	for _, host := range data.hosts {
 		result = append(result, &routableContainer{
 			containerEndpoint:     endpoint,
 			externalContainerName: host,
-			containerID:           containerID,
+			containerId:           containerId,
 			autoScaleUp:           data.autoScaleUp,
 			autoScaleDown:         data.autoScaleDown,
 			autoScaleAsleepMOTD:   data.autoScaleAsleepMOTD,
 			autoScaleLoadingMOTD:  data.autoScaleLoadingMOTD,
+			scalingTarget:         scalingTarget,
 		})
 	}
 	if data.def != nil && *data.def {
 		result = append(result, &routableContainer{
 			containerEndpoint:     endpoint,
 			externalContainerName: "",
-			containerID:           containerID,
+			containerId:           containerId,
 			autoScaleUp:           data.autoScaleUp,
 			autoScaleDown:         data.autoScaleDown,
 			autoScaleAsleepMOTD:   data.autoScaleAsleepMOTD,
 			autoScaleLoadingMOTD:  data.autoScaleLoadingMOTD,
+			scalingTarget:         scalingTarget,
 		})
 	}
 	return result, nil
 }
 
-// applyContainerRoutesLocked reconciles the routes for a single containerID
+// applyContainerRoutesLocked reconciles the routes for a single containerId
 // against the desired set. Caller must hold monitorLock.
-func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerID string, desired []*routableContainer) {
+func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerId string, desired []*routableContainer) {
 	desiredByName := map[string]*routableContainer{}
 	for _, rc := range desired {
 		desiredByName[rc.externalContainerName] = rc
@@ -311,7 +314,7 @@ func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerID string, desir
 
 	// Drop entries previously owned by this container that are no longer desired
 	for name, rc := range w.containerMap {
-		if rc.containerID != containerID {
+		if rc.containerId != containerId {
 			continue
 		}
 		if _, keep := desiredByName[name]; keep {
@@ -327,22 +330,21 @@ func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerID string, desir
 	}
 
 	for _, rs := range desired {
-		scalingTarget := NewDockerScalingTarget(rs.containerID)
 		oldRs, exists := w.containerMap[rs.externalContainerName]
 		if !exists {
 			w.containerMap[rs.externalContainerName] = rs
 			wakerFunc := w.makeWakerFunc(rs)
 			sleeperFunc := w.makeSleeperFunc(rs)
 			if rs.externalContainerName != "" {
-				w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, NamedScalingTarget(rs.containerID), wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			} else {
-				w.routes.SetDefaultRoute(rs.containerEndpoint, NamedScalingTarget(rs.containerID), wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.SetDefaultRoute(rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			}
 			logrus.WithField("routableContainer", rs).Debug("ADD")
 			continue
 		}
 		if oldRs.containerEndpoint == rs.containerEndpoint &&
-			oldRs.containerID == rs.containerID &&
+			oldRs.containerId == rs.containerId &&
 			oldRs.autoScaleUp == rs.autoScaleUp &&
 			oldRs.autoScaleDown == rs.autoScaleDown &&
 			oldRs.autoScaleAsleepMOTD == rs.autoScaleAsleepMOTD &&
@@ -354,9 +356,9 @@ func (w *dockerWatcherImpl) applyContainerRoutesLocked(containerID string, desir
 		sleeperFunc := w.makeSleeperFunc(rs)
 		if rs.externalContainerName != "" {
 			w.routes.RemoveMapping(rs.externalContainerName)
-			w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+			w.routes.CreateMapping(rs.externalContainerName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 		} else {
-			w.routes.SetDefaultRoute(rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+			w.routes.SetDefaultRoute(rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 		}
 		logrus.WithFields(logrus.Fields{"old": oldRs, "new": rs}).Debug("UPDATE")
 	}
@@ -477,10 +479,11 @@ func (w *dockerWatcherImpl) listContainers(ctx context.Context) ([]*routableCont
 	}
 
 	var result []*routableContainer
-	for _, container := range containers {
-		inspect, err := w.client.ContainerInspect(ctx, container.ID)
+	for _, c := range containers {
+		containerId := c.ID
+		inspect, err := w.client.ContainerInspect(ctx, containerId)
 		if err != nil {
-			logrus.WithFields(logrus.Fields{"containerID": container.ID}).WithError(err).Error("Failed to inspect Docker container")
+			logrus.WithFields(logrus.Fields{"containerId": containerId}).WithError(err).Error("Failed to inspect Docker container")
 			continue
 		}
 		data, ok := w.parseContainerData(&inspect)
@@ -493,34 +496,32 @@ func (w *dockerWatcherImpl) listContainers(ctx context.Context) ([]*routableCont
 			endpoint = dockerBackendEndpoint(data.ip, data.port)
 		}
 		logrus.WithField("backendEndpoint", endpoint).
-			WithField("containerID", container.ID).
+			WithField("containerId", containerId).
 			Debug("Found routable Docker container")
 
+		scalingTarget := NewDockerScalingTarget(containerId)
 		for _, host := range data.hosts {
-			result = append(result, &routableContainer{
-				containerEndpoint:     endpoint,
-				externalContainerName: host,
-				containerID:           container.ID,
-				autoScaleUp:           data.autoScaleUp,
-				autoScaleDown:         data.autoScaleDown,
-				autoScaleAsleepMOTD:   data.autoScaleAsleepMOTD,
-				autoScaleLoadingMOTD:  data.autoScaleLoadingMOTD,
-			})
+			result = append(result, newRoutableContainer(endpoint, host, containerId, data, scalingTarget))
 		}
 		if data.def != nil && *data.def {
-			result = append(result, &routableContainer{
-				containerEndpoint:     endpoint,
-				externalContainerName: "",
-				containerID:           container.ID,
-				autoScaleUp:           data.autoScaleUp,
-				autoScaleDown:         data.autoScaleDown,
-				autoScaleAsleepMOTD:   data.autoScaleAsleepMOTD,
-				autoScaleLoadingMOTD:  data.autoScaleLoadingMOTD,
-			})
+			result = append(result, newRoutableContainer(endpoint, "", containerId, data, scalingTarget))
 		}
 	}
 
 	return result, nil
+}
+
+func newRoutableContainer(endpoint string, host string, containerId string, data parsedDockerContainerData, target *DockerScalingTarget) *routableContainer {
+	return &routableContainer{
+		containerEndpoint:     endpoint,
+		externalContainerName: host,
+		containerId:           containerId,
+		autoScaleUp:           data.autoScaleUp,
+		autoScaleDown:         data.autoScaleDown,
+		autoScaleAsleepMOTD:   data.autoScaleAsleepMOTD,
+		autoScaleLoadingMOTD:  data.autoScaleLoadingMOTD,
+		scalingTarget:         target,
+	}
 }
 
 type parsedDockerContainerData struct {
@@ -658,11 +659,8 @@ func (w *dockerWatcherImpl) parseContainerData(container *container.InspectRespo
 				break
 			}
 
-			for _, alias := range endpoint.Aliases {
-				if alias == name {
-					data.ip = dockerEndpointIP(endpoint)
-					break
-				}
+			if slices.Contains(endpoint.Aliases, name) {
+				data.ip = dockerEndpointIP(endpoint)
 			}
 		}
 	} else {
@@ -701,26 +699,27 @@ func (w *dockerWatcherImpl) parseContainerData(container *container.InspectRespo
 	return
 }
 
-// TODO have routableContainer implement ScalingTarget
 type routableContainer struct {
+	ScalingIndicator
 	externalContainerName string
 	containerEndpoint     string
-	containerID           string
+	containerId           string
 	autoScaleUp           bool
 	autoScaleDown         bool
 	autoScaleAsleepMOTD   string
 	autoScaleLoadingMOTD  string
+	scalingTarget         *DockerScalingTarget
 }
 
 type DockerScalingTarget struct {
 	ScalingIndicator
-	containerID string
+	containerId string
 }
 
-func NewDockerScalingTarget(containerID string) *DockerScalingTarget {
+func NewDockerScalingTarget(containerId string) *DockerScalingTarget {
 	return &DockerScalingTarget{
 		ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}},
-		containerID:      containerID,
+		containerId:      containerId,
 	}
 }
 
@@ -728,23 +727,12 @@ func (t *DockerScalingTarget) String() string {
 	if t == nil {
 		return ""
 	}
-	return t.containerID
+	return t.containerId
 }
 
-func (t *DockerScalingTarget) Equal(other ScalingTarget) bool {
-	if t == nil || other == nil {
-		return t == nil && other == nil
-	}
-	otherTarget, ok := other.(*DockerScalingTarget)
-	if !ok {
-		return false
-	}
-	return t.Key() == otherTarget.Key()
-}
-
-func (t *DockerScalingTarget) Key() string {
+func (t *DockerScalingTarget) ScalingKey() string {
 	if t == nil {
 		return ""
 	}
-	return t.containerID
+	return t.containerId
 }

--- a/server/docker_swarm.go
+++ b/server/docker_swarm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -582,10 +583,8 @@ func dockerCheckNetworkName(id string, name string, networkMap map[string]*netwo
 			return true, nil
 		}
 		aliases := networkAliases[id]
-		for _, alias := range aliases {
-			if alias == name {
-				return true, nil
-			}
+		if slices.Contains(aliases, name) {
+			return true, nil
 		}
 		return false, nil
 	}
@@ -983,7 +982,7 @@ func (t *DockerSwarmScalingTarget) String() string {
 	if t == nil {
 		return ""
 	}
-	return t.serviceID
+	return "dockerSwarm{" + t.serviceID + "}"
 }
 
 func (t *DockerSwarmScalingTarget) ScalingKey() string {

--- a/server/docker_swarm.go
+++ b/server/docker_swarm.go
@@ -394,8 +394,7 @@ func (w *dockerSwarmWatcherImpl) reconcileServices(ctx context.Context) error {
 			w.serviceMap[rs.externalServiceName] = rs
 			wakerFunc, sleeperFunc := w.makeServiceLifecycleFuncs(rs)
 			if rs.externalServiceName != "" {
-				w.routes.RemoveMapping(rs.externalServiceName)
-				w.routes.CreateMapping(rs.externalServiceName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.UpdateMapping(rs.externalServiceName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			} else {
 				w.routes.SetDefaultRoute(rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			}

--- a/server/docker_swarm.go
+++ b/server/docker_swarm.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	dockertypes "github.com/docker/docker/api/types"
@@ -33,6 +34,7 @@ func NewDockerSwarmWatcher(socket string, timeout time.Duration, autoScaleUp boo
 	}
 }
 
+// TODO see if routableSwarmService can implement ScalingTarget instead of needing DockerSwarmScalingTarget
 type routableSwarmService struct {
 	externalServiceName       string
 	containerEndpoint         string
@@ -94,7 +96,7 @@ func (w *dockerSwarmWatcherImpl) makeWakerFunc(rs *routableSwarmService) WakerFu
 			logrus.WithFields(logrus.Fields{
 				"serviceID":   serviceID,
 				"serviceName": rs.serviceName,
-			}).Debug("Scaling up Swarm service to 1 replica")
+			}).Debug("IsScaling up Swarm service to 1 replica")
 			one := uint64(1)
 			service.Spec.Mode.Replicated.Replicas = &one
 
@@ -270,7 +272,7 @@ func (w *dockerSwarmWatcherImpl) makeSleeperFunc(rs *routableSwarmService) Sleep
 			logrus.WithFields(logrus.Fields{
 				"serviceID":   serviceID,
 				"serviceName": rs.serviceName,
-			}).Debug("Scaling down Swarm service to 0 replicas")
+			}).Debug("IsScaling down Swarm service to 0 replicas")
 			zero := uint64(0)
 			service.Spec.Mode.Replicated.Replicas = &zero
 
@@ -334,6 +336,7 @@ func (w *dockerSwarmWatcherImpl) reconcileServices(ctx context.Context) error {
 
 	visited := map[string]struct{}{}
 	for _, rs := range services {
+		scalingTarget := NewDockerSwarmScalingTarget(rs.serviceID)
 		// If this is a newly discovered service, set up wakers/sleepers and create the route mapping.
 		if oldRs, ok := w.serviceMap[rs.externalServiceName]; !ok {
 			w.serviceMap[rs.externalServiceName] = rs
@@ -348,9 +351,9 @@ func (w *dockerSwarmWatcherImpl) reconcileServices(ctx context.Context) error {
 
 			wakerFunc, sleeperFunc := w.makeServiceLifecycleFuncs(rs)
 			if rs.externalServiceName != "" {
-				w.routes.CreateMapping(rs.externalServiceName, rs.containerEndpoint, rs.serviceID, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.CreateMapping(rs.externalServiceName, rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			} else {
-				w.routes.SetDefaultRoute(rs.containerEndpoint, rs.serviceID, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.SetDefaultRoute(rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			}
 			w.routes.SetCountdownDeadline(rs.externalServiceName, rs.countdownDeadline)
 			// If the service is already tracked, check if any metadata, endpoint, MOTDs, or deadline
@@ -382,10 +385,10 @@ func (w *dockerSwarmWatcherImpl) reconcileServices(ctx context.Context) error {
 			w.serviceMap[rs.externalServiceName] = rs
 			wakerFunc, sleeperFunc := w.makeServiceLifecycleFuncs(rs)
 			if rs.externalServiceName != "" {
-				w.routes.DeleteMapping(rs.externalServiceName)
-				w.routes.CreateMapping(rs.externalServiceName, rs.containerEndpoint, rs.serviceID, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.RemoveMapping(rs.externalServiceName)
+				w.routes.CreateMapping(rs.externalServiceName, rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			} else {
-				w.routes.SetDefaultRoute(rs.containerEndpoint, rs.serviceID, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.SetDefaultRoute(rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			}
 			w.routes.SetCountdownDeadline(rs.externalServiceName, rs.countdownDeadline)
 			logrus.WithFields(logrus.Fields{"old": oldRs, "new": rs}).Debug("UPDATE")
@@ -396,9 +399,9 @@ func (w *dockerSwarmWatcherImpl) reconcileServices(ctx context.Context) error {
 		if _, ok := visited[rs.externalServiceName]; !ok {
 			delete(w.serviceMap, rs.externalServiceName)
 			if rs.externalServiceName != "" {
-				w.routes.DeleteMapping(rs.externalServiceName)
+				w.routes.RemoveMapping(rs.externalServiceName)
 			} else {
-				w.routes.SetDefaultRoute("", "", nil, nil, "", "")
+				w.routes.RemoveDefaultRoute()
 			}
 			logrus.WithField("routableService", rs).Debug("DELETE")
 		}
@@ -501,9 +504,9 @@ func (w *dockerSwarmWatcherImpl) listServices(ctx context.Context) ([]*routableS
 	}
 
 	networkMap := make(map[string]*network.Inspect)
-	for _, network := range networkList {
-		networkToAdd := network
-		networkMap[network.ID] = &networkToAdd
+	for _, n := range networkList {
+		networkToAdd := n
+		networkMap[n.ID] = &networkToAdd
 	}
 
 	var result []*routableSwarmService
@@ -573,8 +576,8 @@ func dockerCheckNetworkName(id string, name string, networkMap map[string]*netwo
 	if id == name {
 		return true, nil
 	}
-	if network := networkMap[id]; network != nil {
-		if network.Name == name {
+	if n := networkMap[id]; n != nil {
+		if n.Name == name {
 			return true, nil
 		}
 		aliases := networkAliases[id]
@@ -758,8 +761,8 @@ func (w *dockerSwarmWatcherImpl) parseServiceLabels(service *swarm.Service, data
 
 func getNetworkAliases(service *swarm.Service) map[string][]string {
 	networkAliases := map[string][]string{}
-	for _, network := range service.Spec.TaskTemplate.Networks {
-		networkAliases[network.Target] = network.Aliases
+	for _, n := range service.Spec.TaskTemplate.Networks {
+		networkAliases[n.Target] = n.Aliases
 	}
 	return networkAliases
 }
@@ -774,8 +777,8 @@ func resolveTargetNetwork(service *swarm.Service, labelNetwork *string, networkM
 	} else {
 		// Default: Find the first non-ingress network in the task template
 		for _, netSpec := range service.Spec.TaskTemplate.Networks {
-			if network := networkMap[netSpec.Target]; network != nil {
-				if network.Name != "ingress" {
+			if n := networkMap[netSpec.Target]; n != nil {
+				if n.Name != "ingress" {
 					return netSpec.Target
 				}
 			}
@@ -961,4 +964,41 @@ func classifyServiceState(data *parsedDockerServiceData, service *swarm.Service,
 	}
 
 	return true
+}
+
+type DockerSwarmScalingTarget struct {
+	ScalingIndicator
+	serviceID string
+}
+
+func NewDockerSwarmScalingTarget(serviceID string) *DockerSwarmScalingTarget {
+	return &DockerSwarmScalingTarget{
+		ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}},
+		serviceID:        serviceID,
+	}
+}
+
+func (t *DockerSwarmScalingTarget) String() string {
+	if t == nil {
+		return ""
+	}
+	return t.serviceID
+}
+
+func (t *DockerSwarmScalingTarget) Equal(other ScalingTarget) bool {
+	if t == nil || other == nil {
+		return t == nil && other == nil
+	}
+	otherTarget, ok := other.(*DockerSwarmScalingTarget)
+	if !ok {
+		return false
+	}
+	return t.Key() == otherTarget.Key()
+}
+
+func (t *DockerSwarmScalingTarget) Key() string {
+	if t == nil {
+		return ""
+	}
+	return t.serviceID
 }

--- a/server/docker_swarm.go
+++ b/server/docker_swarm.go
@@ -36,6 +36,7 @@ func NewDockerSwarmWatcher(socket string, timeout time.Duration, autoScaleUp boo
 
 // TODO see if routableSwarmService can implement ScalingTarget instead of needing DockerSwarmScalingTarget
 type routableSwarmService struct {
+	ScalingIndicator
 	externalServiceName       string
 	containerEndpoint         string
 	serviceID                 string
@@ -50,6 +51,15 @@ type routableSwarmService struct {
 	autoScaleRestartDelayMOTD string
 	countdownDeadline         time.Time
 	statusState               string
+	scalingTarget             *DockerSwarmScalingTarget
+}
+
+func (r *routableSwarmService) String() string {
+	return r.serviceID
+}
+
+func (r *routableSwarmService) ScalingKey() string {
+	return r.serviceID
 }
 
 type dockerSwarmWatcherImpl struct {
@@ -336,7 +346,6 @@ func (w *dockerSwarmWatcherImpl) reconcileServices(ctx context.Context) error {
 
 	visited := map[string]struct{}{}
 	for _, rs := range services {
-		scalingTarget := NewDockerSwarmScalingTarget(rs.serviceID)
 		// If this is a newly discovered service, set up wakers/sleepers and create the route mapping.
 		if oldRs, ok := w.serviceMap[rs.externalServiceName]; !ok {
 			w.serviceMap[rs.externalServiceName] = rs
@@ -351,9 +360,9 @@ func (w *dockerSwarmWatcherImpl) reconcileServices(ctx context.Context) error {
 
 			wakerFunc, sleeperFunc := w.makeServiceLifecycleFuncs(rs)
 			if rs.externalServiceName != "" {
-				w.routes.CreateMapping(rs.externalServiceName, rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.CreateMapping(rs.externalServiceName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			} else {
-				w.routes.SetDefaultRoute(rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.SetDefaultRoute(rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			}
 			w.routes.SetCountdownDeadline(rs.externalServiceName, rs.countdownDeadline)
 			// If the service is already tracked, check if any metadata, endpoint, MOTDs, or deadline
@@ -386,9 +395,9 @@ func (w *dockerSwarmWatcherImpl) reconcileServices(ctx context.Context) error {
 			wakerFunc, sleeperFunc := w.makeServiceLifecycleFuncs(rs)
 			if rs.externalServiceName != "" {
 				w.routes.RemoveMapping(rs.externalServiceName)
-				w.routes.CreateMapping(rs.externalServiceName, rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.CreateMapping(rs.externalServiceName, rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			} else {
-				w.routes.SetDefaultRoute(rs.containerEndpoint, scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
+				w.routes.SetDefaultRoute(rs.containerEndpoint, rs.scalingTarget, wakerFunc, sleeperFunc, rs.autoScaleAsleepMOTD, rs.autoScaleLoadingMOTD)
 			}
 			w.routes.SetCountdownDeadline(rs.externalServiceName, rs.countdownDeadline)
 			logrus.WithFields(logrus.Fields{"old": oldRs, "new": rs}).Debug("UPDATE")
@@ -520,6 +529,7 @@ func (w *dockerSwarmWatcherImpl) listServices(ctx context.Context) ([]*routableS
 			continue
 		}
 
+		// TODO parsedDockerServiceData probably should be the ScalingTarget to de-dupe on the for...host below
 		data, ok := w.evaluateSwarmService(ctx, &service, networkMap)
 		if !ok {
 			continue
@@ -530,45 +540,37 @@ func (w *dockerSwarmWatcherImpl) listServices(ctx context.Context) ([]*routableS
 			endpoint = fmt.Sprintf("%s:%d", data.ip, data.port)
 		}
 
+		scalingTarget := NewDockerSwarmScalingTarget(data.serviceID)
 		for _, host := range data.hosts {
-			result = append(result, &routableSwarmService{
-				containerEndpoint:         endpoint,
-				externalServiceName:       host,
-				serviceID:                 data.serviceID,
-				serviceName:               data.serviceName,
-				networkID:                 data.networkID,
-				autoScaleUp:               data.autoScaleUp,
-				autoScaleDown:             data.autoScaleDown,
-				autoScaleAsleepMOTD:       data.autoScaleAsleepMOTD,
-				autoScaleLoadingMOTD:      data.autoScaleLoadingMOTD,
-				autoScaleWaitTimeout:      data.autoScaleWaitTimeout,
-				autoScaleFailedMOTD:       data.autoScaleFailedMOTD,
-				autoScaleRestartDelayMOTD: data.autoScaleRestartDelayMOTD,
-				countdownDeadline:         data.countdownDeadline,
-				statusState:               data.statusState,
-			})
+			result = append(result, newRoutableSwarmService(endpoint, host, data, scalingTarget))
 		}
 		if data.def != nil && *data.def {
-			result = append(result, &routableSwarmService{
-				containerEndpoint:         endpoint,
-				externalServiceName:       "",
-				serviceID:                 data.serviceID,
-				serviceName:               data.serviceName,
-				networkID:                 data.networkID,
-				autoScaleUp:               data.autoScaleUp,
-				autoScaleDown:             data.autoScaleDown,
-				autoScaleAsleepMOTD:       data.autoScaleAsleepMOTD,
-				autoScaleLoadingMOTD:      data.autoScaleLoadingMOTD,
-				autoScaleWaitTimeout:      data.autoScaleWaitTimeout,
-				autoScaleFailedMOTD:       data.autoScaleFailedMOTD,
-				autoScaleRestartDelayMOTD: data.autoScaleRestartDelayMOTD,
-				countdownDeadline:         data.countdownDeadline,
-				statusState:               data.statusState,
-			})
+			result = append(result, newRoutableSwarmService(endpoint, "", data, scalingTarget))
 		}
 	}
 
 	return result, nil
+}
+
+func newRoutableSwarmService(endpoint string, host string, data parsedDockerServiceData, target *DockerSwarmScalingTarget) *routableSwarmService {
+	return &routableSwarmService{
+		ScalingIndicator:          ScalingIndicator{scaling: &atomic.Bool{}},
+		containerEndpoint:         endpoint,
+		externalServiceName:       host,
+		serviceID:                 data.serviceID,
+		serviceName:               data.serviceName,
+		networkID:                 data.networkID,
+		autoScaleUp:               data.autoScaleUp,
+		autoScaleDown:             data.autoScaleDown,
+		autoScaleAsleepMOTD:       data.autoScaleAsleepMOTD,
+		autoScaleLoadingMOTD:      data.autoScaleLoadingMOTD,
+		autoScaleWaitTimeout:      data.autoScaleWaitTimeout,
+		autoScaleFailedMOTD:       data.autoScaleFailedMOTD,
+		autoScaleRestartDelayMOTD: data.autoScaleRestartDelayMOTD,
+		countdownDeadline:         data.countdownDeadline,
+		statusState:               data.statusState,
+		scalingTarget:             target,
+	}
 }
 
 func dockerCheckNetworkName(id string, name string, networkMap map[string]*network.Inspect, networkAliases map[string][]string) (bool, error) {
@@ -985,20 +987,6 @@ func (t *DockerSwarmScalingTarget) String() string {
 	return t.serviceID
 }
 
-func (t *DockerSwarmScalingTarget) Equal(other ScalingTarget) bool {
-	if t == nil || other == nil {
-		return t == nil && other == nil
-	}
-	otherTarget, ok := other.(*DockerSwarmScalingTarget)
-	if !ok {
-		return false
-	}
-	return t.Key() == otherTarget.Key()
-}
-
-func (t *DockerSwarmScalingTarget) Key() string {
-	if t == nil {
-		return ""
-	}
+func (t *DockerSwarmScalingTarget) ScalingKey() string {
 	return t.serviceID
 }

--- a/server/docker_swarm.go
+++ b/server/docker_swarm.go
@@ -35,9 +35,7 @@ func NewDockerSwarmWatcher(socket string, timeout time.Duration, autoScaleUp boo
 	}
 }
 
-// TODO see if routableSwarmService can implement ScalingTarget instead of needing DockerSwarmScalingTarget
 type routableSwarmService struct {
-	ScalingIndicator
 	externalServiceName       string
 	containerEndpoint         string
 	serviceID                 string
@@ -56,11 +54,8 @@ type routableSwarmService struct {
 }
 
 func (r *routableSwarmService) String() string {
-	return r.serviceID
-}
-
-func (r *routableSwarmService) ScalingKey() string {
-	return r.serviceID
+	return fmt.Sprintf("routableSwarmService{externalName=%s, endpoint=%s, serviceID=%s, serviceName=%s, networkID=%s, autoScaleUp=%v, autoScaleDown=%v, autoScaleAsleepMOTD=%s, autoScaleLoadingMOTD=%s, autoScaleFailedMOTD=%s, autoScaleRestartDelayMOTD=%s, statusState=%s, scalingTarget=%v}",
+		r.externalServiceName, r.containerEndpoint, r.serviceID, r.serviceName, r.networkID, r.autoScaleUp, r.autoScaleDown, r.autoScaleAsleepMOTD, r.autoScaleLoadingMOTD, r.autoScaleFailedMOTD, r.autoScaleRestartDelayMOTD, r.statusState, r.scalingTarget)
 }
 
 type dockerSwarmWatcherImpl struct {
@@ -554,7 +549,6 @@ func (w *dockerSwarmWatcherImpl) listServices(ctx context.Context) ([]*routableS
 
 func newRoutableSwarmService(endpoint string, host string, data parsedDockerServiceData, target *DockerSwarmScalingTarget) *routableSwarmService {
 	return &routableSwarmService{
-		ScalingIndicator:          ScalingIndicator{scaling: &atomic.Bool{}},
 		containerEndpoint:         endpoint,
 		externalServiceName:       host,
 		serviceID:                 data.serviceID,

--- a/server/docker_swarm.go
+++ b/server/docker_swarm.go
@@ -535,7 +535,7 @@ func (w *dockerSwarmWatcherImpl) listServices(ctx context.Context) ([]*routableS
 			endpoint = fmt.Sprintf("%s:%d", data.ip, data.port)
 		}
 
-		scalingTarget := NewDockerSwarmScalingTarget(data.serviceID)
+		scalingTarget := NewDockerSwarmScalingTarget(data.serviceID, data.serviceName)
 		for _, host := range data.hosts {
 			result = append(result, newRoutableSwarmService(endpoint, host, data, scalingTarget))
 		}
@@ -963,12 +963,14 @@ func classifyServiceState(data *parsedDockerServiceData, service *swarm.Service,
 type DockerSwarmScalingTarget struct {
 	ScalingIndicator
 	serviceID string
+	name      string
 }
 
-func NewDockerSwarmScalingTarget(serviceID string) *DockerSwarmScalingTarget {
+func NewDockerSwarmScalingTarget(serviceID string, name string) *DockerSwarmScalingTarget {
 	return &DockerSwarmScalingTarget{
 		ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}},
 		serviceID:        serviceID,
+		name:             name,
 	}
 }
 
@@ -976,7 +978,7 @@ func (t *DockerSwarmScalingTarget) String() string {
 	if t == nil {
 		return ""
 	}
-	return "dockerSwarm{" + t.serviceID + "}"
+	return fmt.Sprintf("dockerSwarm{id=%s, name=%s}", t.serviceID, t.name)
 }
 
 func (t *DockerSwarmScalingTarget) ScalingKey() string {

--- a/server/down_scaler.go
+++ b/server/down_scaler.go
@@ -8,14 +8,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// TODO need to re-evalute the awkwardness of DownScaler in the overall whole flow.
+// TODO need to re-evaluate the awkwardness of DownScaler in the overall whole flow.
 // For example, I'm not sure where waker/sleeper fits and it's part of a Routes<->DownScaler cycle.
 // It also has an "enabled" flag, but why not just have this whole thing be optional/nil-able as the caller end.
+// Maybe it needs to be renamed too, such as ScalingTracker or ScalingTimers
 
 type IDownScaler interface {
 	Reset()
-	Start(ctx context.Context, backendEndpoint string, routes IRoutes)
-	Cancel(backendEndpoint string)
+	Start(ctx context.Context, scalingTarget ScalingTarget, routes IRoutes)
+	Cancel(scalingTarget ScalingTarget)
 }
 
 func NewDownScaler(enabled bool, delay time.Duration) IDownScaler {
@@ -43,7 +44,7 @@ func (ds *downScalerImpl) Reset() {
 	ds.contextCancellations = make(map[string]context.CancelFunc)
 }
 
-func (ds *downScalerImpl) Start(ctx context.Context, backendEndpoint string, routes IRoutes) {
+func (ds *downScalerImpl) Start(ctx context.Context, scalingTarget ScalingTarget, routes IRoutes) {
 	ds.Lock()
 	defer ds.Unlock()
 
@@ -52,16 +53,16 @@ func (ds *downScalerImpl) Start(ctx context.Context, backendEndpoint string, rou
 	}
 
 	// If an existing scale down routine exists, cancel it
-	if scaleDownCancel, ok := ds.contextCancellations[backendEndpoint]; ok {
+	if scaleDownCancel, ok := ds.contextCancellations[scalingTarget.Key()]; ok {
 		scaleDownCancel()
 	}
 
 	scaleDownContext, scaleDownContextCancellation := context.WithCancel(ctx)
-	ds.contextCancellations[backendEndpoint] = scaleDownContextCancellation
-	go ds.scaleDown(scaleDownContext, backendEndpoint, routes)
+	ds.contextCancellations[scalingTarget.Key()] = scaleDownContextCancellation
+	go ds.scaleDown(scaleDownContext, scalingTarget, routes)
 }
 
-func (ds *downScalerImpl) Cancel(backendEndpoint string) {
+func (ds *downScalerImpl) Cancel(scalingTarget ScalingTarget) {
 	ds.Lock()
 	defer ds.Unlock()
 
@@ -69,15 +70,15 @@ func (ds *downScalerImpl) Cancel(backendEndpoint string) {
 		return
 	}
 
-	if scaleDownContextCancellation, ok := ds.contextCancellations[backendEndpoint]; ok {
-		logrus.WithField("backendEndpoint", backendEndpoint).Debug("Canceling scale down")
+	if scaleDownContextCancellation, ok := ds.contextCancellations[scalingTarget.Key()]; ok {
+		logrus.WithField("scalingTarget", scalingTarget).Debug("Canceling scale down")
 		scaleDownContextCancellation()
-		delete(ds.contextCancellations, backendEndpoint)
+		delete(ds.contextCancellations, scalingTarget.Key())
 	}
 }
 
-func (ds *downScalerImpl) scaleDown(ctx context.Context, backendEndpoint string, routes IRoutes) {
-	logrus.WithField("backendEndpoint", backendEndpoint).
+func (ds *downScalerImpl) scaleDown(ctx context.Context, scalingTarget ScalingTarget, routes IRoutes) {
+	logrus.WithField("scalingTarget", scalingTarget).
 		WithField("delay", ds.delay).
 		Debug("Starting scale-down timer")
 	for {
@@ -85,23 +86,25 @@ func (ds *downScalerImpl) scaleDown(ctx context.Context, backendEndpoint string,
 		case <-ctx.Done():
 			return
 		case <-time.After(ds.delay):
-			sleepers := routes.GetSleepers(backendEndpoint)
-			logrus.WithField("backendEndpoint", backendEndpoint).
-				WithField("sleepers", len(sleepers)).
-				Debug("Found sleepers to use")
-			if len(sleepers) == 0 {
+			sleeper := routes.GetSleeper(scalingTarget)
+			logrus.WithField("scalingTarget", scalingTarget).
+				WithField("sleeper", sleeper != nil).
+				Debug("Found sleeper to use")
+			if sleeper == nil {
 				return
 			}
-			for _, sleeper := range sleepers {
-				go func(s SleeperFunc) {
-					err := s(ctx)
+			go func() {
+				if scalingTarget.StartScaling() {
+					defer scalingTarget.EndScaling()
+
+					err := sleeper(ctx)
 					if err != nil {
 						logrus.WithError(err).
-							WithField("backendEndpoint", backendEndpoint).
+							WithField("scalingTarget", scalingTarget).
 							Error("Error while executing sleeper function")
 					}
-				}(sleeper)
-			}
+				}
+			}()
 			return
 		}
 	}

--- a/server/down_scaler.go
+++ b/server/down_scaler.go
@@ -53,12 +53,12 @@ func (ds *downScalerImpl) Start(ctx context.Context, scalingTarget ScalingTarget
 	}
 
 	// If an existing scale down routine exists, cancel it
-	if scaleDownCancel, ok := ds.contextCancellations[scalingTarget.Key()]; ok {
+	if scaleDownCancel, ok := ds.contextCancellations[scalingTarget.ScalingKey()]; ok {
 		scaleDownCancel()
 	}
 
 	scaleDownContext, scaleDownContextCancellation := context.WithCancel(ctx)
-	ds.contextCancellations[scalingTarget.Key()] = scaleDownContextCancellation
+	ds.contextCancellations[scalingTarget.ScalingKey()] = scaleDownContextCancellation
 	go ds.scaleDown(scaleDownContext, scalingTarget, routes)
 }
 
@@ -70,10 +70,10 @@ func (ds *downScalerImpl) Cancel(scalingTarget ScalingTarget) {
 		return
 	}
 
-	if scaleDownContextCancellation, ok := ds.contextCancellations[scalingTarget.Key()]; ok {
+	if scaleDownContextCancellation, ok := ds.contextCancellations[scalingTarget.ScalingKey()]; ok {
 		logrus.WithField("scalingTarget", scalingTarget).Debug("Canceling scale down")
 		scaleDownContextCancellation()
-		delete(ds.contextCancellations, scalingTarget.Key())
+		delete(ds.contextCancellations, scalingTarget.ScalingKey())
 	}
 }
 

--- a/server/down_scaler.go
+++ b/server/down_scaler.go
@@ -83,7 +83,7 @@ func (ds *downScalerImpl) Start(ctx context.Context, scalingTarget ScalingTarget
 		if scalingTarget.StartScaling() {
 			defer scalingTarget.EndScaling()
 
-			logrus.WithField("scalingTarget", scalingTarget).Info("Scaling-down")
+			logrus.WithField("scalingTarget", scalingTarget).Info("Scaling down backend server")
 			if err := sleeper(ctx); err != nil {
 				logrus.WithError(err).
 					WithField("scalingTarget", scalingTarget).

--- a/server/down_scaler.go
+++ b/server/down_scaler.go
@@ -83,7 +83,7 @@ func (ds *downScalerImpl) Start(ctx context.Context, scalingTarget ScalingTarget
 		if scalingTarget.StartScaling() {
 			defer scalingTarget.EndScaling()
 
-			logrus.WithField("scalingTarget", scalingTarget).Debug("Executing sleeper function")
+			logrus.WithField("scalingTarget", scalingTarget).Info("Scaling-down")
 			if err := sleeper(ctx); err != nil {
 				logrus.WithError(err).
 					WithField("scalingTarget", scalingTarget).

--- a/server/down_scaler.go
+++ b/server/down_scaler.go
@@ -74,14 +74,16 @@ func (ds *downScalerImpl) Start(ctx context.Context, scalingTarget ScalingTarget
 
 		sleeper := routes.GetSleeper(scalingTarget)
 		logrus.WithField("scalingTarget", scalingTarget).
-			WithField("sleeper", sleeper != nil).
-			Debug("Found sleeper to use")
+			WithField("found", sleeper != nil).
+			Debug("Looking for sleeper to use")
 		if sleeper == nil {
 			return
 		}
 
 		if scalingTarget.StartScaling() {
 			defer scalingTarget.EndScaling()
+
+			logrus.WithField("scalingTarget", scalingTarget).Debug("Executing sleeper function")
 			if err := sleeper(ctx); err != nil {
 				logrus.WithError(err).
 					WithField("scalingTarget", scalingTarget).

--- a/server/down_scaler.go
+++ b/server/down_scaler.go
@@ -9,39 +9,38 @@ import (
 )
 
 // TODO need to re-evaluate the awkwardness of DownScaler in the overall whole flow.
-// For example, I'm not sure where waker/sleeper fits and it's part of a Routes<->DownScaler cycle.
-// It also has an "enabled" flag, but why not just have this whole thing be optional/nil-able as the caller end.
-// Maybe it needs to be renamed too, such as ScalingTracker or ScalingTimers
+// Maybe it needs to be renamed too, such as  DownScalingTimers
 
 type IDownScaler interface {
 	Reset()
 	Start(ctx context.Context, scalingTarget ScalingTarget, routes IRoutes)
 	Cancel(scalingTarget ScalingTarget)
+	HandleContextDone(ctx context.Context)
 }
 
 func NewDownScaler(enabled bool, delay time.Duration) IDownScaler {
-	ds := &downScalerImpl{
-		enabled:              enabled,
-		delay:                delay,
-		contextCancellations: make(map[string]context.CancelFunc),
+	return &downScalerImpl{
+		enabled: enabled,
+		delay:   delay,
+		timers:  make(map[string]*time.Timer),
 	}
-
-	return ds
 }
 
 type downScalerImpl struct {
-	sync.RWMutex
-	enabled              bool
-	delay                time.Duration
-	contextCancellations map[string]context.CancelFunc
+	sync.Mutex
+	enabled bool
+	delay   time.Duration
+	timers  map[string]*time.Timer
 }
 
 func (ds *downScalerImpl) Reset() {
-	// Cancel all existing scale down routines
-	for _, scaleDownCancel := range ds.contextCancellations {
-		scaleDownCancel()
+	ds.Lock()
+	defer ds.Unlock()
+
+	for _, t := range ds.timers {
+		t.Stop()
 	}
-	ds.contextCancellations = make(map[string]context.CancelFunc)
+	ds.timers = make(map[string]*time.Timer)
 }
 
 func (ds *downScalerImpl) Start(ctx context.Context, scalingTarget ScalingTarget, routes IRoutes) {
@@ -52,14 +51,44 @@ func (ds *downScalerImpl) Start(ctx context.Context, scalingTarget ScalingTarget
 		return
 	}
 
-	// If an existing scale down routine exists, cancel it
-	if scaleDownCancel, ok := ds.contextCancellations[scalingTarget.ScalingKey()]; ok {
-		scaleDownCancel()
+	key := scalingTarget.ScalingKey()
+	if _, exists := ds.timers[key]; exists {
+		// Already scheduled; prevent duplicate scale-down for same target
+		return
 	}
 
-	scaleDownContext, scaleDownContextCancellation := context.WithCancel(ctx)
-	ds.contextCancellations[scalingTarget.ScalingKey()] = scaleDownContextCancellation
-	go ds.scaleDown(scaleDownContext, scalingTarget, routes)
+	logrus.WithField("scalingTarget", scalingTarget).
+		WithField("delay", ds.delay).
+		Debug("Starting scale-down timer")
+
+	ds.timers[key] = time.AfterFunc(ds.delay, func() {
+		ds.Lock()
+		delete(ds.timers, key)
+		ds.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		sleeper := routes.GetSleeper(scalingTarget)
+		logrus.WithField("scalingTarget", scalingTarget).
+			WithField("sleeper", sleeper != nil).
+			Debug("Found sleeper to use")
+		if sleeper == nil {
+			return
+		}
+
+		if scalingTarget.StartScaling() {
+			defer scalingTarget.EndScaling()
+			if err := sleeper(ctx); err != nil {
+				logrus.WithError(err).
+					WithField("scalingTarget", scalingTarget).
+					Error("Error while executing sleeper function")
+			}
+		}
+	})
 }
 
 func (ds *downScalerImpl) Cancel(scalingTarget ScalingTarget) {
@@ -70,42 +99,17 @@ func (ds *downScalerImpl) Cancel(scalingTarget ScalingTarget) {
 		return
 	}
 
-	if scaleDownContextCancellation, ok := ds.contextCancellations[scalingTarget.ScalingKey()]; ok {
-		logrus.WithField("scalingTarget", scalingTarget).Debug("Canceling scale down")
-		scaleDownContextCancellation()
-		delete(ds.contextCancellations, scalingTarget.ScalingKey())
+	key := scalingTarget.ScalingKey()
+	if t, ok := ds.timers[key]; ok {
+		logrus.WithField("scalingTarget", scalingTarget).Debug("Canceling scale-down timer")
+		t.Stop()
+		delete(ds.timers, key)
 	}
 }
 
-func (ds *downScalerImpl) scaleDown(ctx context.Context, scalingTarget ScalingTarget, routes IRoutes) {
-	logrus.WithField("scalingTarget", scalingTarget).
-		WithField("delay", ds.delay).
-		Debug("Starting scale-down timer")
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(ds.delay):
-			sleeper := routes.GetSleeper(scalingTarget)
-			logrus.WithField("scalingTarget", scalingTarget).
-				WithField("sleeper", sleeper != nil).
-				Debug("Found sleeper to use")
-			if sleeper == nil {
-				return
-			}
-			go func() {
-				if scalingTarget.StartScaling() {
-					defer scalingTarget.EndScaling()
-
-					err := sleeper(ctx)
-					if err != nil {
-						logrus.WithError(err).
-							WithField("scalingTarget", scalingTarget).
-							Error("Error while executing sleeper function")
-					}
-				}
-			}()
-			return
-		}
-	}
+func (ds *downScalerImpl) HandleContextDone(ctx context.Context) {
+	go func() {
+		<-ctx.Done()
+		ds.Reset()
+	}()
 }

--- a/server/k8s.go
+++ b/server/k8s.go
@@ -317,7 +317,7 @@ func (w *K8sWatcher) buildDetails(service *core.Service, externalServiceName str
 	endpoint := net.JoinHostPort(clusterIp, port)
 
 	routingEndpoint := endpoint
-	scalingTarget := NewK8sScalingTarget(endpoint)
+	scalingTarget := NewK8sScalingTarget(endpoint, service.Name)
 
 	if proxyServerName, exists := service.Annotations[AnnotationProxyServerName]; exists && proxyServerName != "" {
 		// Ensure the proxy address has a port
@@ -515,13 +515,15 @@ func (w *K8sWatcher) buildScaleFunction(service *core.Service, from int32, to in
 
 type K8sScalingTarget struct {
 	ScalingIndicator
-	endpoint string
+	endpoint    string
+	serviceName string
 }
 
-func NewK8sScalingTarget(endpoint string) *K8sScalingTarget {
+func NewK8sScalingTarget(endpoint string, serviceName string) *K8sScalingTarget {
 	return &K8sScalingTarget{
 		ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}},
 		endpoint:         endpoint,
+		serviceName:      serviceName,
 	}
 }
 
@@ -529,7 +531,7 @@ func (t *K8sScalingTarget) String() string {
 	if t == nil {
 		return ""
 	}
-	return "k8s{" + t.endpoint + "}"
+	return fmt.Sprintf("k8s{endpoint=%s, serviceName=%s}", t.endpoint, t.serviceName)
 }
 
 func (t *K8sScalingTarget) ScalingKey() string {

--- a/server/k8s.go
+++ b/server/k8s.go
@@ -500,20 +500,6 @@ func (t *K8sScalingTarget) String() string {
 	return t.endpoint
 }
 
-func (t *K8sScalingTarget) Equal(other ScalingTarget) bool {
-	if t == nil || other == nil {
-		return t == nil && other == nil
-	}
-	otherTarget, ok := other.(*K8sScalingTarget)
-	if !ok {
-		return false
-	}
-	return t.Key() == otherTarget.Key()
-}
-
-func (t *K8sScalingTarget) Key() string {
-	if t == nil {
-		return ""
-	}
+func (t *K8sScalingTarget) ScalingKey() string {
 	return t.endpoint
 }

--- a/server/k8s.go
+++ b/server/k8s.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -34,7 +35,7 @@ const (
 )
 
 // K8sWatcher is a RouteFinder that can find routes from kubernetes services.
-// It also watches for stateful sets to auto scale up/down, if enabled.
+// It also watches for stateful sets to auto-scale up/down, if enabled.
 type K8sWatcher struct {
 	sync.RWMutex
 	config        *rest.Config
@@ -180,7 +181,7 @@ func (w *K8sWatcher) handleUpdate(oldObj interface{}, newObj interface{}) {
 			"old": oldRoutableService,
 		}).Debug("UPDATE")
 		if oldRoutableService.externalServiceName != "" {
-			w.routesHandler.DeleteMapping(oldRoutableService.externalServiceName)
+			w.routesHandler.RemoveMapping(oldRoutableService.externalServiceName)
 		}
 	}
 
@@ -204,9 +205,9 @@ func (w *K8sWatcher) handleDelete(obj interface{}) {
 			logrus.WithField("routableService", routableService).Debug("DELETE")
 
 			if routableService.externalServiceName != "" {
-				w.routesHandler.DeleteMapping(routableService.externalServiceName)
+				w.routesHandler.RemoveMapping(routableService.externalServiceName)
 			} else {
-				w.routesHandler.SetDefaultRoute("", "", nil, nil, "", "")
+				w.routesHandler.RemoveDefaultRoute()
 			}
 		}
 	}
@@ -231,7 +232,7 @@ func (w *K8sWatcher) handleAdd(obj interface{}) {
 type routableService struct {
 	externalServiceName  string
 	containerEndpoint    string
-	scalingTarget        string
+	scalingTarget        ScalingTarget
 	autoScaleUp          WakerFunc
 	autoScaleDown        SleeperFunc
 	autoScaleAsleepMOTD  string
@@ -283,7 +284,7 @@ func (w *K8sWatcher) buildDetails(service *core.Service, externalServiceName str
 	endpoint := net.JoinHostPort(clusterIp, port)
 
 	routingEndpoint := endpoint
-	scalingTarget := endpoint // Default to service endpoint for scaling
+	scalingTarget := NewK8sScalingTarget(endpoint)
 
 	if proxyServerName, exists := service.Annotations[AnnotationProxyServerName]; exists && proxyServerName != "" {
 		// Ensure the proxy address has a port
@@ -319,7 +320,7 @@ func (w *K8sWatcher) buildDetails(service *core.Service, externalServiceName str
 		externalServiceName:  externalServiceName,
 		containerEndpoint:    routingEndpoint,
 		scalingTarget:        scalingTarget,
-		autoScaleUp:          buildK8sWaker(routingEndpoint, wakerFunc, waitTimeout),
+		autoScaleUp:          buildK8sWaker(routingEndpoint, scalingTarget, wakerFunc, waitTimeout),
 		autoScaleDown:        w.buildScaleFunction(service, 1, 0),
 		autoScaleAsleepMOTD:  autoScaleAsleepMOTD,
 		autoScaleLoadingMOTD: autoScaleLoadingMOTD,
@@ -327,32 +328,36 @@ func (w *K8sWatcher) buildDetails(service *core.Service, externalServiceName str
 	return rs
 }
 
-func buildK8sWaker(endpoint string, scaleUp SleeperFunc, waitTimeout time.Duration) WakerFunc {
+func buildK8sWaker(endpoint string, target ScalingTarget, scaleUp SleeperFunc, waitTimeout time.Duration) WakerFunc {
 	if scaleUp == nil {
 		return nil
 	}
 	return func(ctx context.Context) (string, error) {
-		if err := scaleUp(ctx); err != nil {
-			return "", err
-		}
+		if target.StartScaling() {
+			defer target.EndScaling()
 
-		deadline := time.Now().Add(waitTimeout)
-		for {
-			conn, err := net.DialTimeout("tcp", endpoint, 1*time.Second)
-			if err == nil {
-				_ = conn.Close()
-				break
+			if err := scaleUp(ctx); err != nil {
+				return "", err
 			}
-			if ctx.Err() != nil {
-				return endpoint, ctx.Err()
-			}
-			if time.Now().After(deadline) {
-				return endpoint, fmt.Errorf("timeout waiting for K8s backend to become reachable at %s", endpoint)
-			}
-			select {
-			case <-ctx.Done():
-				return endpoint, ctx.Err()
-			case <-time.After(500 * time.Millisecond):
+
+			deadline := time.Now().Add(waitTimeout)
+			for {
+				conn, err := net.DialTimeout("tcp", endpoint, 1*time.Second)
+				if err == nil {
+					_ = conn.Close()
+					break
+				}
+				if ctx.Err() != nil {
+					return endpoint, ctx.Err()
+				}
+				if time.Now().After(deadline) {
+					return endpoint, fmt.Errorf("timeout waiting for K8s backend to become reachable at %s", endpoint)
+				}
+				select {
+				case <-ctx.Done():
+					return endpoint, ctx.Err()
+				case <-time.After(500 * time.Millisecond):
+				}
 			}
 		}
 
@@ -363,7 +368,7 @@ func buildK8sWaker(endpoint string, scaleUp SleeperFunc, waitTimeout time.Durati
 // buildScaleFunction generates a SleeperFunc to scale StatefulSets based on specified criteria and service annotations.
 // Will return nil if the service should not be auto-scaled due config or annotation.
 func (w *K8sWatcher) buildScaleFunction(service *core.Service, from int32, to int32) SleeperFunc {
-	// Currently, annotations can only be used to opt-out of auto-scaling.
+	// Currently, annotations can only be used to opt out of auto-scaling.
 	// However, this logic is prepared also for opt-in, as it returns a `SleeperFunc` when flags are false but annotations are set to `enabled`.
 	if from <= to {
 		enabled, exists := service.Annotations[AnnotationAutoScaleUp]
@@ -474,4 +479,41 @@ func (w *K8sWatcher) buildScaleFunction(service *core.Service, from int32, to in
 		}
 		return nil
 	}
+}
+
+type K8sScalingTarget struct {
+	ScalingIndicator
+	endpoint string
+}
+
+func NewK8sScalingTarget(endpoint string) *K8sScalingTarget {
+	return &K8sScalingTarget{
+		ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}},
+		endpoint:         endpoint,
+	}
+}
+
+func (t *K8sScalingTarget) String() string {
+	if t == nil {
+		return ""
+	}
+	return t.endpoint
+}
+
+func (t *K8sScalingTarget) Equal(other ScalingTarget) bool {
+	if t == nil || other == nil {
+		return t == nil && other == nil
+	}
+	otherTarget, ok := other.(*K8sScalingTarget)
+	if !ok {
+		return false
+	}
+	return t.Key() == otherTarget.Key()
+}
+
+func (t *K8sScalingTarget) Key() string {
+	if t == nil {
+		return ""
+	}
+	return t.endpoint
 }

--- a/server/k8s.go
+++ b/server/k8s.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/avast/retry-go/v5"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	apps "k8s.io/api/apps/v1"
@@ -33,11 +32,6 @@ const (
 	AnnotationAutoScaleAsleepMOTD  = "mc-router.itzg.me/autoScaleAsleepMOTD"
 	AnnotationAutoScaleLoadingMOTD = "mc-router.itzg.me/autoScaleLoadingMOTD"
 	AnnotationAutoScaleWaitTimeout = "mc-router.itzg.me/autoScaleWaitTimeout"
-)
-
-const (
-	backendReadyRetryDelay     = 500 * time.Millisecond
-	backendReadyConnectTimeout = 250 * time.Millisecond
 )
 
 // K8sWatcher is a RouteFinder that can find routes from kubernetes services.
@@ -386,40 +380,7 @@ func buildK8sWaker(endpoint string, scaleUp SleeperFunc, waitTimeout time.Durati
 			WithField("waitTimeout", waitTimeout).
 			Debug("Waiting for K8s backend to become reachable")
 
-		// Apply overall deadline to retries
-		retryCtx, retryCancel := context.WithTimeout(ctx, waitTimeout)
-		defer retryCancel()
-
-		const backendReadyRetryMaxDelay = 1 * time.Second
-		retryErr := retry.New(
-			retry.Context(retryCtx),
-			retry.DelayType(retry.BackOffDelay),
-			retry.Delay(backendReadyRetryDelay),
-			retry.MaxDelay(backendReadyRetryMaxDelay),
-			retry.UntilSucceeded(),
-			retry.OnRetry(func(n uint, err error) {
-				logrus.
-					WithField("endpoint", endpoint).
-					WithField("attempt", n).
-					WithError(err).
-					Debug("Retrying K8s backend reachability")
-			}),
-		).Do(func() error {
-			conn, err := net.DialTimeout("tcp", endpoint, backendReadyConnectTimeout)
-			if err == nil {
-				_ = conn.Close()
-				logrus.WithField("endpoint", endpoint).Debug("K8s backend is now reachable")
-				return nil
-			}
-			return err
-		})
-		if errors.Is(retryErr, context.DeadlineExceeded) {
-			return endpoint, fmt.Errorf("timeout waiting for K8s backend to become reachable at %s", endpoint)
-		} else if retryErr != nil {
-			return endpoint, fmt.Errorf("error waiting for K8s backend to become reachable at %s: %w", endpoint, retryErr)
-		}
-
-		return endpoint, nil
+		return waitForBackend(ctx, endpoint, waitTimeout)
 	}
 }
 

--- a/server/k8s.go
+++ b/server/k8s.go
@@ -176,23 +176,33 @@ func (w *K8sWatcher) handleDeleteStatefulSet() func(obj interface{}) {
 
 // oldObj and newObj are expected to be *v1.Service
 func (w *K8sWatcher) handleUpdate(oldObj interface{}, newObj interface{}) {
-	for _, oldRoutableService := range w.extractRoutableServices(oldObj) {
-		logrus.WithFields(logrus.Fields{
-			"old": oldRoutableService,
-		}).Debug("UPDATE")
-		if oldRoutableService.externalServiceName != "" {
-			w.routesHandler.RemoveMapping(oldRoutableService.externalServiceName)
+	newServices := w.extractRoutableServices(newObj)
+
+	// Build a set of new service names for quick lookup
+	newNames := make(map[string]struct{}, len(newServices))
+	for _, rs := range newServices {
+		if rs.externalServiceName != "" {
+			newNames[rs.externalServiceName] = struct{}{}
 		}
 	}
 
-	for _, newRoutableService := range w.extractRoutableServices(newObj) {
-		logrus.WithFields(logrus.Fields{
-			"new": newRoutableService,
-		}).Debug("UPDATE")
-		if newRoutableService.externalServiceName != "" {
-			w.routesHandler.CreateMapping(newRoutableService.externalServiceName, newRoutableService.containerEndpoint, newRoutableService.scalingTarget, newRoutableService.autoScaleUp, newRoutableService.autoScaleDown, newRoutableService.autoScaleAsleepMOTD, newRoutableService.autoScaleLoadingMOTD)
+	// Remove routes whose server address is no longer present in the new object
+	for _, oldRS := range w.extractRoutableServices(oldObj) {
+		logrus.WithFields(logrus.Fields{"old": oldRS}).Debug("UPDATE")
+		if oldRS.externalServiceName != "" {
+			if _, stillPresent := newNames[oldRS.externalServiceName]; !stillPresent {
+				w.routesHandler.RemoveMapping(oldRS.externalServiceName)
+			}
+		}
+	}
+
+	// Update or create routes for new addresses; use UpdateMapping (no timer bounce)
+	for _, newRS := range newServices {
+		logrus.WithFields(logrus.Fields{"new": newRS}).Debug("UPDATE")
+		if newRS.externalServiceName != "" {
+			w.routesHandler.UpdateMapping(newRS.externalServiceName, newRS.containerEndpoint, newRS.scalingTarget, newRS.autoScaleUp, newRS.autoScaleDown, newRS.autoScaleAsleepMOTD, newRS.autoScaleLoadingMOTD)
 		} else {
-			w.routesHandler.SetDefaultRoute(newRoutableService.containerEndpoint, newRoutableService.scalingTarget, newRoutableService.autoScaleUp, newRoutableService.autoScaleDown, newRoutableService.autoScaleAsleepMOTD, newRoutableService.autoScaleLoadingMOTD)
+			w.routesHandler.SetDefaultRoute(newRS.containerEndpoint, newRS.scalingTarget, newRS.autoScaleUp, newRS.autoScaleDown, newRS.autoScaleAsleepMOTD, newRS.autoScaleLoadingMOTD)
 		}
 	}
 }

--- a/server/k8s.go
+++ b/server/k8s.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/avast/retry-go/v5"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	apps "k8s.io/api/apps/v1"
@@ -32,6 +33,11 @@ const (
 	AnnotationAutoScaleAsleepMOTD  = "mc-router.itzg.me/autoScaleAsleepMOTD"
 	AnnotationAutoScaleLoadingMOTD = "mc-router.itzg.me/autoScaleLoadingMOTD"
 	AnnotationAutoScaleWaitTimeout = "mc-router.itzg.me/autoScaleWaitTimeout"
+)
+
+const (
+	backendReadyRetryDelay     = 500 * time.Millisecond
+	backendReadyConnectTimeout = 250 * time.Millisecond
 )
 
 // K8sWatcher is a RouteFinder that can find routes from kubernetes services.
@@ -107,6 +113,7 @@ func (w *K8sWatcher) Start(ctx context.Context, handler RoutesHandler) error {
 			UpdateFunc: w.handleUpdate,
 		},
 	})
+	logrus.Debug("Starting service informer")
 	go serviceController.RunWithContext(ctx)
 
 	w.mappings = make(map[string]string)
@@ -126,6 +133,7 @@ func (w *K8sWatcher) Start(ctx context.Context, handler RoutesHandler) error {
 			},
 		})
 
+		logrus.Debug("Starting stateful set informer")
 		go statefulSetController.RunWithContext(ctx)
 	}
 
@@ -133,20 +141,22 @@ func (w *K8sWatcher) Start(ctx context.Context, handler RoutesHandler) error {
 	return nil
 }
 
-func (w *K8sWatcher) handleAddStatefulSet() func(obj interface{}) {
-	return func(obj interface{}) {
+func (w *K8sWatcher) handleAddStatefulSet() func(obj any) {
+	return func(obj any) {
 		statefulSet, ok := obj.(*apps.StatefulSet)
 		if !ok {
 			return
 		}
+		logrus.WithField("statefulSet", infoForSts(statefulSet)).
+			Debug("ADD")
 		w.RLock()
 		defer w.RUnlock()
 		w.mappings[statefulSet.Spec.ServiceName] = statefulSet.Name
 	}
 }
 
-func (w *K8sWatcher) handleUpdateStatefulSet() func(oldObj interface{}, newObj interface{}) {
-	return func(oldObj, newObj interface{}) {
+func (w *K8sWatcher) handleUpdateStatefulSet() func(oldObj any, newObj any) {
+	return func(oldObj, newObj any) {
 		oldStatefulSet, ok := oldObj.(*apps.StatefulSet)
 		if !ok {
 			return
@@ -155,6 +165,8 @@ func (w *K8sWatcher) handleUpdateStatefulSet() func(oldObj interface{}, newObj i
 		if !ok {
 			return
 		}
+		logrus.WithFields(logrus.Fields{"old": infoForSts(oldStatefulSet), "new": infoForSts(newStatefulSet)}).
+			Debug("UPDATE")
 		w.RLock()
 		defer w.RUnlock()
 		delete(w.mappings, oldStatefulSet.Spec.ServiceName)
@@ -162,12 +174,24 @@ func (w *K8sWatcher) handleUpdateStatefulSet() func(oldObj interface{}, newObj i
 	}
 }
 
-func (w *K8sWatcher) handleDeleteStatefulSet() func(obj interface{}) {
-	return func(obj interface{}) {
+func infoForSts(sts *apps.StatefulSet) string {
+	return fmt.Sprintf("statefulSet{name=%s, replicas=%d, readyReplicas=%d, currentReplicas=%d, serviceName=%s}",
+		sts.Name,
+		sts.Status.Replicas,
+		sts.Status.ReadyReplicas,
+		sts.Status.CurrentReplicas,
+		sts.Spec.ServiceName,
+	)
+}
+
+func (w *K8sWatcher) handleDeleteStatefulSet() func(obj any) {
+	return func(obj any) {
 		statefulSet, ok := obj.(*apps.StatefulSet)
 		if !ok {
 			return
 		}
+		logrus.WithField("statefulSet", infoForSts(statefulSet)).
+			Debug("DELETE")
 		w.RLock()
 		defer w.RUnlock()
 		delete(w.mappings, statefulSet.Spec.ServiceName)
@@ -175,7 +199,7 @@ func (w *K8sWatcher) handleDeleteStatefulSet() func(obj interface{}) {
 }
 
 // oldObj and newObj are expected to be *v1.Service
-func (w *K8sWatcher) handleUpdate(oldObj interface{}, newObj interface{}) {
+func (w *K8sWatcher) handleUpdate(oldObj any, newObj any) {
 	newServices := w.extractRoutableServices(newObj)
 
 	// Build a set of new service names for quick lookup
@@ -208,7 +232,7 @@ func (w *K8sWatcher) handleUpdate(oldObj interface{}, newObj interface{}) {
 }
 
 // obj is expected to be a *v1.Service
-func (w *K8sWatcher) handleDelete(obj interface{}) {
+func (w *K8sWatcher) handleDelete(obj any) {
 	routableServices := w.extractRoutableServices(obj)
 	for _, routableService := range routableServices {
 		if routableService != nil {
@@ -224,7 +248,7 @@ func (w *K8sWatcher) handleDelete(obj interface{}) {
 }
 
 // obj is expected to be a *v1.Service
-func (w *K8sWatcher) handleAdd(obj interface{}) {
+func (w *K8sWatcher) handleAdd(obj any) {
 	routableServices := w.extractRoutableServices(obj)
 	for _, routableService := range routableServices {
 		if routableService != nil {
@@ -249,8 +273,13 @@ type routableService struct {
 	autoScaleLoadingMOTD string
 }
 
+func (r *routableService) String() string {
+	return fmt.Sprintf("routableService{externalName=%s, endpoint=%s, scalingTarget=%s, autoScaleUp=%t, autoScaleDown=%t}",
+		r.externalServiceName, r.containerEndpoint, r.scalingTarget, r.autoScaleUp != nil, r.autoScaleDown != nil)
+}
+
 // obj is expected to be a *v1.Service
-func (w *K8sWatcher) extractRoutableServices(obj interface{}) []*routableService {
+func (w *K8sWatcher) extractRoutableServices(obj any) []*routableService {
 	service, ok := obj.(*core.Service)
 	if !ok {
 		return nil
@@ -330,7 +359,7 @@ func (w *K8sWatcher) buildDetails(service *core.Service, externalServiceName str
 		externalServiceName:  externalServiceName,
 		containerEndpoint:    routingEndpoint,
 		scalingTarget:        scalingTarget,
-		autoScaleUp:          buildK8sWaker(routingEndpoint, scalingTarget, wakerFunc, waitTimeout),
+		autoScaleUp:          buildK8sWaker(routingEndpoint, wakerFunc, waitTimeout),
 		autoScaleDown:        w.buildScaleFunction(service, 1, 0),
 		autoScaleAsleepMOTD:  autoScaleAsleepMOTD,
 		autoScaleLoadingMOTD: autoScaleLoadingMOTD,
@@ -338,37 +367,56 @@ func (w *K8sWatcher) buildDetails(service *core.Service, externalServiceName str
 	return rs
 }
 
-func buildK8sWaker(endpoint string, target ScalingTarget, scaleUp SleeperFunc, waitTimeout time.Duration) WakerFunc {
+func buildK8sWaker(endpoint string, scaleUp SleeperFunc, waitTimeout time.Duration) WakerFunc {
 	if scaleUp == nil {
 		return nil
 	}
 	return func(ctx context.Context) (string, error) {
-		if target.StartScaling() {
-			defer target.EndScaling()
+		// The connector already holds the StartScaling lock before calling the waker,
+		// so we go straight to scaling up without a redundant StartScaling check.
+		logrus.
+			WithField("endpoint", endpoint).
+			Debug("Scaling up K8s StatefulSet replicas to 1")
+		if err := scaleUp(ctx); err != nil {
+			return "", err
+		}
 
-			if err := scaleUp(ctx); err != nil {
-				return "", err
-			}
+		logrus.
+			WithField("endpoint", endpoint).
+			WithField("waitTimeout", waitTimeout).
+			Debug("Waiting for K8s backend to become reachable")
 
-			deadline := time.Now().Add(waitTimeout)
-			for {
-				conn, err := net.DialTimeout("tcp", endpoint, 1*time.Second)
-				if err == nil {
-					_ = conn.Close()
-					break
-				}
-				if ctx.Err() != nil {
-					return endpoint, ctx.Err()
-				}
-				if time.Now().After(deadline) {
-					return endpoint, fmt.Errorf("timeout waiting for K8s backend to become reachable at %s", endpoint)
-				}
-				select {
-				case <-ctx.Done():
-					return endpoint, ctx.Err()
-				case <-time.After(500 * time.Millisecond):
-				}
+		// Apply overall deadline to retries
+		retryCtx, retryCancel := context.WithTimeout(ctx, waitTimeout)
+		defer retryCancel()
+
+		const backendReadyRetryMaxDelay = 1 * time.Second
+		retryErr := retry.New(
+			retry.Context(retryCtx),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(backendReadyRetryDelay),
+			retry.MaxDelay(backendReadyRetryMaxDelay),
+			retry.UntilSucceeded(),
+			retry.OnRetry(func(n uint, err error) {
+				logrus.
+					WithField("endpoint", endpoint).
+					WithField("attempt", n).
+					WithError(err).
+					Debug("Retrying K8s backend reachability")
+			}),
+		).Do(func() error {
+			conn, err := net.DialTimeout("tcp", endpoint, backendReadyConnectTimeout)
+			if err == nil {
+				_ = conn.Close()
+				logrus.WithField("endpoint", endpoint).Debug("K8s backend is now reachable")
+				return nil
 			}
+			return err
+		})
+		if errors.Is(retryErr, context.DeadlineExceeded) {
+			return endpoint, fmt.Errorf("timeout waiting for K8s backend to become reachable at %s", endpoint)
+		} else if retryErr != nil {
+			return endpoint, fmt.Errorf("error waiting for K8s backend to become reachable at %s: %w", endpoint, retryErr)
 		}
 
 		return endpoint, nil
@@ -421,9 +469,21 @@ func (w *K8sWatcher) buildScaleFunction(service *core.Service, from int32, to in
 		}
 
 	}
+
+	logrus.WithField("service", service.Name).
+		WithField("from", from).
+		WithField("to", to).
+		Debug("Service auto-scale enabled")
 	return func(ctx context.Context) error {
 		serviceName := service.Name
 		if statefulSetName, exists := w.mappings[serviceName]; exists {
+			logrus.
+				WithField("service", serviceName).
+				WithField("from", from).
+				WithField("to", to).
+				WithField("statefulSet", statefulSetName).
+				Debug("Scaling StatefulSet")
+
 			// Get current replicas to check if scaling is needed
 			if scale, err := w.clientset.AppsV1().StatefulSets(service.Namespace).GetScale(ctx, statefulSetName, meta.GetOptions{}); err == nil {
 				replicas := scale.Status.Replicas
@@ -487,6 +547,7 @@ func (w *K8sWatcher) buildScaleFunction(service *core.Service, from int32, to in
 				return fmt.Errorf("GetScale failed for StatefulSet %s: %w", statefulSetName, err)
 			}
 		}
+		logrus.WithField("service", serviceName).Warn("Service has no StatefulSet associated - skipping scaling")
 		return nil
 	}
 }
@@ -507,7 +568,7 @@ func (t *K8sScalingTarget) String() string {
 	if t == nil {
 		return ""
 	}
-	return t.endpoint
+	return "k8s{" + t.endpoint + "}"
 }
 
 func (t *K8sScalingTarget) ScalingKey() string {

--- a/server/k8s.go
+++ b/server/k8s.go
@@ -317,7 +317,6 @@ func (w *K8sWatcher) buildDetails(service *core.Service, externalServiceName str
 	endpoint := net.JoinHostPort(clusterIp, port)
 
 	routingEndpoint := endpoint
-	scalingTarget := NewK8sScalingTarget(endpoint, service.Name)
 
 	if proxyServerName, exists := service.Annotations[AnnotationProxyServerName]; exists && proxyServerName != "" {
 		// Ensure the proxy address has a port
@@ -327,6 +326,7 @@ func (w *K8sWatcher) buildDetails(service *core.Service, externalServiceName str
 		routingEndpoint = proxyServerName
 		// scalingTarget remains the service endpoint (already set above)
 	}
+	scalingTarget := NewK8sScalingTarget(service.Namespace, service.Name)
 
 	autoScaleAsleepMOTD := ""
 	autoScaleLoadingMOTD := ""
@@ -515,14 +515,13 @@ func (w *K8sWatcher) buildScaleFunction(service *core.Service, from int32, to in
 
 type K8sScalingTarget struct {
 	ScalingIndicator
-	endpoint    string
+	namespace   string
 	serviceName string
 }
 
-func NewK8sScalingTarget(endpoint string, serviceName string) *K8sScalingTarget {
+func NewK8sScalingTarget(namespace string, serviceName string) *K8sScalingTarget {
 	return &K8sScalingTarget{
 		ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}},
-		endpoint:         endpoint,
 		serviceName:      serviceName,
 	}
 }
@@ -531,9 +530,9 @@ func (t *K8sScalingTarget) String() string {
 	if t == nil {
 		return ""
 	}
-	return fmt.Sprintf("k8s{endpoint=%s, serviceName=%s}", t.endpoint, t.serviceName)
+	return fmt.Sprintf("k8s{serviceName=%s, namespace=%s}", t.serviceName, t.namespace)
 }
 
 func (t *K8sScalingTarget) ScalingKey() string {
-	return t.endpoint
+	return t.namespace + ":" + t.serviceName
 }

--- a/server/k8s_test.go
+++ b/server/k8s_test.go
@@ -445,13 +445,13 @@ func TestK8s_proxyServerNameScaleEndpoint(t *testing.T) {
 	}
 
 	svc := v1.Service{}
-	err := json.Unmarshal([]byte(`{"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "mc.example.com", "mc-router.itzg.me/proxyServerName": "velocity:25577"}}, "spec":{"clusterIP": "10.0.0.5"}}`), &svc)
+	err := json.Unmarshal([]byte(`{"metadata": {"name": "mc-example", "annotations": {"mc-router.itzg.me/externalServerName": "mc.example.com", "mc-router.itzg.me/proxyServerName": "velocity:25577"}}, "spec":{"clusterIP": "10.0.0.5"}}`), &svc)
 	require.NoError(t, err)
 
 	watcher.handleAdd(&svc)
 
 	// Verify CreateMapping was called with the correct scaleKey (original endpoint)
-	routesHandler.AssertCalled(t, "CreateMapping", "mc.example.com", "velocity:25577", NewK8sScalingTarget("10.0.0.5:25565"), mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	routesHandler.AssertCalled(t, "CreateMapping", "mc.example.com", "velocity:25577", NewK8sScalingTarget("default", "mc-example"), mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func setupRoutesHandlerMock() *MockedRoutesHandler {
@@ -473,7 +473,7 @@ func TestK8s_proxyServerNameUpdate(t *testing.T) {
 
 	// Start with proxy
 	initialSvc := v1.Service{}
-	err := json.Unmarshal([]byte(`{"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "mc.example.com", "mc-router.itzg.me/proxyServerName": "velocity:25577"}}, "spec":{"clusterIP": "10.0.0.5"}}`), &initialSvc)
+	err := json.Unmarshal([]byte(`{"metadata": {"name": "mc-example", "annotations": {"mc-router.itzg.me/externalServerName": "mc.example.com", "mc-router.itzg.me/proxyServerName": "velocity:25577"}}, "spec":{"clusterIP": "10.0.0.5"}}`), &initialSvc)
 	require.NoError(t, err)
 
 	watcher.handleAdd(&initialSvc)
@@ -498,7 +498,7 @@ func TestK8s_autoScaleWithoutProxy(t *testing.T) {
 
 	// Service WITHOUT proxyServerName but WITH autoScaleUp/Down annotations
 	svc := v1.Service{}
-	err := json.Unmarshal([]byte(`{"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "atm-10.example.com", "mc-router.itzg.me/autoScaleUp": "true", "mc-router.itzg.me/autoScaleDown": "true"}}, "spec":{"clusterIP": "10.0.0.10"}}`), &svc)
+	err := json.Unmarshal([]byte(`{"metadata": {"name": "atm-10", "annotations": {"mc-router.itzg.me/externalServerName": "atm-10.example.com", "mc-router.itzg.me/autoScaleUp": "true", "mc-router.itzg.me/autoScaleDown": "true"}}, "spec":{"clusterIP": "10.0.0.10"}}`), &svc)
 	require.NoError(t, err)
 
 	watcher.handleAdd(&svc)
@@ -508,7 +508,7 @@ func TestK8s_autoScaleWithoutProxy(t *testing.T) {
 
 	// CRITICAL: Verify scaleKey is set to the service endpoint (not empty)
 	// This ensures auto-scaling targets the correct StatefulSet
-	routesHandler.AssertCalled(t, "CreateMapping", "atm-10.example.com", "10.0.0.10:25565", NewK8sScalingTarget("10.0.0.10:25565"), mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	routesHandler.AssertCalled(t, "CreateMapping", "atm-10.example.com", "10.0.0.10:25565", NewK8sScalingTarget("default", "atm-10"), mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestBuildK8sWaker_NilScaleUp(t *testing.T) {
@@ -579,10 +579,10 @@ func TestK8s_motdAnnotations(t *testing.T) {
 	}
 
 	svc := v1.Service{}
-	err := json.Unmarshal([]byte(`{"metadata": {"annotations": {"mc-router.itzg.me/externalServerName": "mc.example.com", "mc-router.itzg.me/autoScaleUp": "true", "mc-router.itzg.me/autoScaleAsleepMOTD": "Server is sleeping", "mc-router.itzg.me/autoScaleLoadingMOTD": "Server is starting"}}, "spec":{"clusterIP": "10.0.0.5"}}`), &svc)
+	err := json.Unmarshal([]byte(`{"metadata": {"name": "mc-example", "annotations": {"mc-router.itzg.me/externalServerName": "mc.example.com", "mc-router.itzg.me/autoScaleUp": "true", "mc-router.itzg.me/autoScaleAsleepMOTD": "Server is sleeping", "mc-router.itzg.me/autoScaleLoadingMOTD": "Server is starting"}}, "spec":{"clusterIP": "10.0.0.5"}}`), &svc)
 	require.NoError(t, err)
 
 	watcher.handleAdd(&svc)
 
-	routesHandler.AssertCalled(t, "CreateMapping", "mc.example.com", "10.0.0.5:25565", NewK8sScalingTarget("10.0.0.5:25565"), mock.Anything, mock.Anything, "Server is sleeping", "Server is starting")
+	routesHandler.AssertCalled(t, "CreateMapping", "mc.example.com", "10.0.0.5:25565", NewK8sScalingTarget("default", "mc-example"), mock.Anything, mock.Anything, "Server is sleeping", "Server is starting")
 }

--- a/server/k8s_test.go
+++ b/server/k8s_test.go
@@ -512,7 +512,7 @@ func TestK8s_autoScaleWithoutProxy(t *testing.T) {
 }
 
 func TestBuildK8sWaker_NilScaleUp(t *testing.T) {
-	waker := buildK8sWaker("10.0.0.1:25565", nil, nil, 60*time.Second)
+	waker := buildK8sWaker("10.0.0.1:25565", nil, 60*time.Second)
 	assert.Nil(t, waker, "buildK8sWaker should return nil when scaleUp is nil")
 }
 
@@ -532,8 +532,7 @@ func TestBuildK8sWaker_WaitsForEndpoint(t *testing.T) {
 		return nil
 	}
 
-	scalingTarget := NewK8sScalingTarget(endpoint)
-	waker := buildK8sWaker(endpoint, scalingTarget, scaleUp, 60*time.Second)
+	waker := buildK8sWaker(endpoint, scaleUp, 60*time.Second)
 	require.NotNil(t, waker)
 
 	result, err := waker(context.Background())
@@ -548,8 +547,7 @@ func TestBuildK8sWaker_ScaleUpError(t *testing.T) {
 	}
 
 	endpoint := "10.0.0.1:25565"
-	scalingTarget := NewK8sScalingTarget(endpoint)
-	waker := buildK8sWaker(endpoint, scalingTarget, scaleUp, 60*time.Second)
+	waker := buildK8sWaker(endpoint, scaleUp, 60*time.Second)
 	require.NotNil(t, waker)
 
 	_, err := waker(context.Background())
@@ -563,8 +561,7 @@ func TestBuildK8sWaker_ContextCancellation(t *testing.T) {
 	}
 
 	endpoint := "192.0.2.1:65534"
-	scalingTarget := NewK8sScalingTarget(endpoint)
-	waker := buildK8sWaker(endpoint, scalingTarget, scaleUp, 60*time.Second)
+	waker := buildK8sWaker(endpoint, scaleUp, 60*time.Second)
 	require.NotNil(t, waker)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/server/k8s_test.go
+++ b/server/k8s_test.go
@@ -65,6 +65,14 @@ func (m *MockedRoutesHandler) RemoveMapping(serverAddress string) bool {
 	return args.Bool(0)
 }
 
+func (m *MockedRoutesHandler) UpdateMapping(serverAddress string, backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
+	m.MethodCalled("UpdateMapping", serverAddress, backend, scalingTarget, waker, sleeper, asleepMOTD, loadingMOTD)
+	if m.routes == nil {
+		m.routes = make(map[string]string)
+	}
+	m.routes[serverAddress] = backend
+}
+
 func TestK8sWatcherImpl_handleAddThenUpdate(t *testing.T) {
 	type scenario struct {
 		server  string
@@ -186,12 +194,7 @@ func TestK8sWatcherImpl_handleAddThenUpdate(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			routesHandler := new(MockedRoutesHandler)
-			routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-			routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-			routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-			routesHandler.On("RemoveMapping", mock.Anything).Return(true)
-			routesHandler.On("RemoveDefaultRoute").Return()
+			routesHandler := setupRoutesHandlerMock()
 
 			watcher := &K8sWatcher{
 				routesHandler: routesHandler,
@@ -265,12 +268,7 @@ func TestK8sWatcherImpl_handleAddThenDelete(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			routesHandler := new(MockedRoutesHandler)
-			routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-			routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-			routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-			routesHandler.On("RemoveMapping", mock.Anything).Return(true)
-			routesHandler.On("RemoveDefaultRoute").Return()
+			routesHandler := setupRoutesHandlerMock()
 
 			watcher := &K8sWatcher{
 				routesHandler: routesHandler,
@@ -362,13 +360,7 @@ func TestK8s_externalName(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			routesHandler := new(MockedRoutesHandler)
-			routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-			routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-			routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-			routesHandler.On("RemoveMapping", mock.Anything).Return(true)
-			routesHandler.On("RemoveDefaultRoute").Return()
-
+			routesHandler := setupRoutesHandlerMock()
 			watcher := &K8sWatcher{
 				routesHandler: routesHandler,
 			}
@@ -429,13 +421,7 @@ func TestK8s_proxyServerName(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			routesHandler := new(MockedRoutesHandler)
-			routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-			routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-			routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-			routesHandler.On("RemoveMapping", mock.Anything).Return(true)
-			routesHandler.On("RemoveDefaultRoute").Return()
-
+			routesHandler := setupRoutesHandlerMock()
 			watcher := &K8sWatcher{
 				routesHandler: routesHandler,
 			}
@@ -453,12 +439,7 @@ func TestK8s_proxyServerName(t *testing.T) {
 }
 
 func TestK8s_proxyServerNameScaleEndpoint(t *testing.T) {
-	routesHandler := new(MockedRoutesHandler)
-	routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-	routesHandler.On("RemoveMapping", mock.Anything).Return(true)
-
+	routesHandler := setupRoutesHandlerMock()
 	watcher := &K8sWatcher{
 		routesHandler: routesHandler,
 	}
@@ -473,13 +454,19 @@ func TestK8s_proxyServerNameScaleEndpoint(t *testing.T) {
 	routesHandler.AssertCalled(t, "CreateMapping", "mc.example.com", "velocity:25577", NewK8sScalingTarget("10.0.0.5:25565"), mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestK8s_proxyServerNameUpdate(t *testing.T) {
+func setupRoutesHandlerMock() *MockedRoutesHandler {
 	routesHandler := new(MockedRoutesHandler)
 	routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
 	routesHandler.On("RemoveMapping", mock.Anything).Return(true)
+	routesHandler.On("UpdateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	routesHandler.On("RemoveDefaultRoute").Return()
+	routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
+	return routesHandler
+}
 
+func TestK8s_proxyServerNameUpdate(t *testing.T) {
+	routesHandler := setupRoutesHandlerMock()
 	watcher := &K8sWatcher{
 		routesHandler: routesHandler,
 	}
@@ -502,12 +489,7 @@ func TestK8s_proxyServerNameUpdate(t *testing.T) {
 }
 
 func TestK8s_autoScaleWithoutProxy(t *testing.T) {
-	routesHandler := new(MockedRoutesHandler)
-	routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-	routesHandler.On("RemoveMapping", mock.Anything).Return(true)
-
+	routesHandler := setupRoutesHandlerMock()
 	watcher := &K8sWatcher{
 		autoScaleUp:   true,
 		autoScaleDown: true,
@@ -593,12 +575,7 @@ func TestBuildK8sWaker_ContextCancellation(t *testing.T) {
 }
 
 func TestK8s_motdAnnotations(t *testing.T) {
-	routesHandler := new(MockedRoutesHandler)
-	routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-	routesHandler.On("RemoveMapping", mock.Anything).Return(true)
-
+	routesHandler := setupRoutesHandlerMock()
 	watcher := &K8sWatcher{
 		autoScaleUp:   true,
 		routesHandler: routesHandler,

--- a/server/k8s_test.go
+++ b/server/k8s_test.go
@@ -30,20 +30,25 @@ func (m *MockedRoutesHandler) GetBackendForServer(server string) string {
 	}
 }
 
-func (m *MockedRoutesHandler) CreateMapping(serverAddress string, backend string, scaleKey string, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
-	m.MethodCalled("CreateMapping", serverAddress, backend, scaleKey, waker, sleeper, asleepMOTD, loadingMOTD)
+func (m *MockedRoutesHandler) CreateMapping(serverAddress string, backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
+	m.MethodCalled("CreateMapping", serverAddress, backend, scalingTarget, waker, sleeper, asleepMOTD, loadingMOTD)
 	if m.routes == nil {
 		m.routes = make(map[string]string)
 	}
 	m.routes[serverAddress] = backend
 }
 
-func (m *MockedRoutesHandler) SetDefaultRoute(backend string, scaleKey string, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
-	m.MethodCalled("SetDefaultRoute", backend, scaleKey, waker, sleeper, asleepMOTD, loadingMOTD)
+func (m *MockedRoutesHandler) SetDefaultRoute(backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
+	m.MethodCalled("SetDefaultRoute", backend, scalingTarget, waker, sleeper, asleepMOTD, loadingMOTD)
 	if m.routes == nil {
 		m.routes = make(map[string]string)
 	}
 	m.defaultBackend = backend
+}
+
+func (m *MockedRoutesHandler) RemoveDefaultRoute() {
+	m.MethodCalled("RemoveDefaultRoute")
+	m.defaultBackend = ""
 }
 
 func (m *MockedRoutesHandler) GetAsleepMOTD(serverAddress string) string {
@@ -51,8 +56,8 @@ func (m *MockedRoutesHandler) GetAsleepMOTD(serverAddress string) string {
 	return args.String(0)
 }
 
-func (m *MockedRoutesHandler) DeleteMapping(serverAddress string) bool {
-	args := m.MethodCalled("DeleteMapping", serverAddress)
+func (m *MockedRoutesHandler) RemoveMapping(serverAddress string) bool {
+	args := m.MethodCalled("RemoveMapping", serverAddress)
 	if m.routes == nil {
 		m.routes = make(map[string]string)
 	}
@@ -185,7 +190,8 @@ func TestK8sWatcherImpl_handleAddThenUpdate(t *testing.T) {
 			routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-			routesHandler.On("DeleteMapping", mock.Anything).Return(true)
+			routesHandler.On("RemoveMapping", mock.Anything).Return(true)
+			routesHandler.On("RemoveDefaultRoute").Return()
 
 			watcher := &K8sWatcher{
 				routesHandler: routesHandler,
@@ -263,7 +269,8 @@ func TestK8sWatcherImpl_handleAddThenDelete(t *testing.T) {
 			routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-			routesHandler.On("DeleteMapping", mock.Anything).Return(true)
+			routesHandler.On("RemoveMapping", mock.Anything).Return(true)
+			routesHandler.On("RemoveDefaultRoute").Return()
 
 			watcher := &K8sWatcher{
 				routesHandler: routesHandler,
@@ -359,7 +366,8 @@ func TestK8s_externalName(t *testing.T) {
 			routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-			routesHandler.On("DeleteMapping", mock.Anything).Return(true)
+			routesHandler.On("RemoveMapping", mock.Anything).Return(true)
+			routesHandler.On("RemoveDefaultRoute").Return()
 
 			watcher := &K8sWatcher{
 				routesHandler: routesHandler,
@@ -425,7 +433,8 @@ func TestK8s_proxyServerName(t *testing.T) {
 			routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-			routesHandler.On("DeleteMapping", mock.Anything).Return(true)
+			routesHandler.On("RemoveMapping", mock.Anything).Return(true)
+			routesHandler.On("RemoveDefaultRoute").Return()
 
 			watcher := &K8sWatcher{
 				routesHandler: routesHandler,
@@ -448,7 +457,7 @@ func TestK8s_proxyServerNameScaleEndpoint(t *testing.T) {
 	routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-	routesHandler.On("DeleteMapping", mock.Anything).Return(true)
+	routesHandler.On("RemoveMapping", mock.Anything).Return(true)
 
 	watcher := &K8sWatcher{
 		routesHandler: routesHandler,
@@ -461,7 +470,7 @@ func TestK8s_proxyServerNameScaleEndpoint(t *testing.T) {
 	watcher.handleAdd(&svc)
 
 	// Verify CreateMapping was called with the correct scaleKey (original endpoint)
-	routesHandler.AssertCalled(t, "CreateMapping", "mc.example.com", "velocity:25577", "10.0.0.5:25565", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	routesHandler.AssertCalled(t, "CreateMapping", "mc.example.com", "velocity:25577", NewK8sScalingTarget("10.0.0.5:25565"), mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestK8s_proxyServerNameUpdate(t *testing.T) {
@@ -469,7 +478,7 @@ func TestK8s_proxyServerNameUpdate(t *testing.T) {
 	routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-	routesHandler.On("DeleteMapping", mock.Anything).Return(true)
+	routesHandler.On("RemoveMapping", mock.Anything).Return(true)
 
 	watcher := &K8sWatcher{
 		routesHandler: routesHandler,
@@ -497,7 +506,7 @@ func TestK8s_autoScaleWithoutProxy(t *testing.T) {
 	routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-	routesHandler.On("DeleteMapping", mock.Anything).Return(true)
+	routesHandler.On("RemoveMapping", mock.Anything).Return(true)
 
 	watcher := &K8sWatcher{
 		autoScaleUp:   true,
@@ -517,18 +526,21 @@ func TestK8s_autoScaleWithoutProxy(t *testing.T) {
 
 	// CRITICAL: Verify scaleKey is set to the service endpoint (not empty)
 	// This ensures auto-scaling targets the correct StatefulSet
-	routesHandler.AssertCalled(t, "CreateMapping", "atm-10.example.com", "10.0.0.10:25565", "10.0.0.10:25565", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	routesHandler.AssertCalled(t, "CreateMapping", "atm-10.example.com", "10.0.0.10:25565", NewK8sScalingTarget("10.0.0.10:25565"), mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestBuildK8sWaker_NilScaleUp(t *testing.T) {
-	waker := buildK8sWaker("10.0.0.1:25565", nil, 60*time.Second)
+	waker := buildK8sWaker("10.0.0.1:25565", nil, nil, 60*time.Second)
 	assert.Nil(t, waker, "buildK8sWaker should return nil when scaleUp is nil")
 }
 
 func TestBuildK8sWaker_WaitsForEndpoint(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer ln.Close()
+	defer func(ln net.Listener) {
+		err := ln.Close()
+		assert.NoError(t, err)
+	}(ln)
 
 	endpoint := ln.Addr().String()
 
@@ -538,7 +550,8 @@ func TestBuildK8sWaker_WaitsForEndpoint(t *testing.T) {
 		return nil
 	}
 
-	waker := buildK8sWaker(endpoint, scaleUp, 60*time.Second)
+	scalingTarget := NewK8sScalingTarget(endpoint)
+	waker := buildK8sWaker(endpoint, scalingTarget, scaleUp, 60*time.Second)
 	require.NotNil(t, waker)
 
 	result, err := waker(context.Background())
@@ -552,7 +565,9 @@ func TestBuildK8sWaker_ScaleUpError(t *testing.T) {
 		return fmt.Errorf("scale up failed")
 	}
 
-	waker := buildK8sWaker("10.0.0.1:25565", scaleUp, 60*time.Second)
+	endpoint := "10.0.0.1:25565"
+	scalingTarget := NewK8sScalingTarget(endpoint)
+	waker := buildK8sWaker(endpoint, scalingTarget, scaleUp, 60*time.Second)
 	require.NotNil(t, waker)
 
 	_, err := waker(context.Background())
@@ -565,7 +580,9 @@ func TestBuildK8sWaker_ContextCancellation(t *testing.T) {
 		return nil
 	}
 
-	waker := buildK8sWaker("192.0.2.1:65534", scaleUp, 60*time.Second)
+	endpoint := "192.0.2.1:65534"
+	scalingTarget := NewK8sScalingTarget(endpoint)
+	waker := buildK8sWaker(endpoint, scalingTarget, scaleUp, 60*time.Second)
 	require.NotNil(t, waker)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -580,7 +597,7 @@ func TestK8s_motdAnnotations(t *testing.T) {
 	routesHandler.On("CreateMapping", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	routesHandler.On("SetDefaultRoute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	routesHandler.On("GetAsleepMOTD", mock.Anything).Return("")
-	routesHandler.On("DeleteMapping", mock.Anything).Return(true)
+	routesHandler.On("RemoveMapping", mock.Anything).Return(true)
 
 	watcher := &K8sWatcher{
 		autoScaleUp:   true,
@@ -593,5 +610,5 @@ func TestK8s_motdAnnotations(t *testing.T) {
 
 	watcher.handleAdd(&svc)
 
-	routesHandler.AssertCalled(t, "CreateMapping", "mc.example.com", "10.0.0.5:25565", "10.0.0.5:25565", mock.Anything, mock.Anything, "Server is sleeping", "Server is starting")
+	routesHandler.AssertCalled(t, "CreateMapping", "mc.example.com", "10.0.0.5:25565", NewK8sScalingTarget("10.0.0.5:25565"), mock.Anything, mock.Anything, "Server is sleeping", "Server is starting")
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -27,6 +27,11 @@ type RouteFinder interface {
 
 type RoutesHandler interface {
 	CreateMapping(serverAddress string, backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string)
+	// UpdateMapping atomically replaces the backend for an existing route without touching the
+	// scale-down timer. Use this instead of RemoveMapping+CreateMapping when the server address
+	// itself has not changed, so the timer bounce (cancel-on-remove, start-on-create) is avoided.
+	// If backend is empty the timer is cancelled (container stopped externally).
+	UpdateMapping(serverAddress string, backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string)
 	SetDefaultRoute(backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string)
 	RemoveDefaultRoute()
 	// RemoveMapping requests that the serverAddress be removed from routes.
@@ -370,9 +375,38 @@ func (r *routesImpl) CreateMapping(serverAddress string, backend string, scaling
 		listener.OnRouteAdded(serverAddress, backend)
 	}
 
-	// Trigger auto-scale down when mapping is created to ensure servers are shut down if router restarts
-	if r.downScaler != nil && scalingTarget != nil {
+	// Trigger auto-scale down when mapping is created to ensure servers are shut down if router restarts.
+	// Only start the timer when backend is non-empty — an empty backend means the server is already
+	// asleep/stopped (e.g. a Docker stop event updated the route), so there is nothing to scale down.
+	if r.downScaler != nil && scalingTarget != nil && backend != "" {
 		r.downScaler.Start(r.ctx, scalingTarget, r)
+	}
+}
+
+// UpdateMapping atomically replaces the backend for an existing route without touching the
+// scale-down timer — the connector owns the timer once a connection is active. When backend
+// is empty (container stopped externally) the timer is cancelled so it doesn't fire needlessly.
+func (r *routesImpl) UpdateMapping(serverAddress string, backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
+	r.Lock()
+	defer r.Unlock()
+
+	serverAddress = strings.ToLower(serverAddress)
+
+	logrus.WithFields(logrus.Fields{
+		"serverAddress": serverAddress,
+		"backend":       backend,
+	}).Info("Updated route mapping")
+	r.mappings[serverAddress] = mapping{backend: backend, scalingTarget: scalingTarget, waker: waker, sleeper: sleeper, asleepMOTD: asleepMOTD, loadingMOTD: loadingMOTD}
+
+	for _, listener := range r.routesListeners {
+		listener.OnRouteRemoved(serverAddress)
+		listener.OnRouteAdded(serverAddress, backend)
+	}
+
+	// Cancel the timer when the backend disappears (container stopped externally).
+	// Don't start a new timer when backend is non-empty — the connector manages that.
+	if r.downScaler != nil && scalingTarget != nil && backend == "" {
+		r.downScaler.Cancel(scalingTarget)
 	}
 }
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -10,23 +10,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// TODO make sure WakerFunc and SleeperFunc are guarded by ScalingTarget.StartScaling and EndScaling-
 // WakerFunc is a function that wakes up a server and returns its address.
 type WakerFunc func(ctx context.Context) (string, error)
 
 // SleeperFunc is a function that puts a server to sleep.
 type SleeperFunc func(ctx context.Context) error
-
-func buildWakerFromSleeper(endpoint string, sleeper SleeperFunc) WakerFunc {
-	if sleeper == nil {
-		return nil
-	}
-	return func(ctx context.Context) (string, error) {
-		if err := sleeper(ctx); err != nil {
-			return "", err
-		}
-		return endpoint, nil
-	}
-}
 
 var tcpShieldPattern = regexp.MustCompile("///.*")
 
@@ -37,11 +26,12 @@ type RouteFinder interface {
 }
 
 type RoutesHandler interface {
-	CreateMapping(serverAddress string, backend string, scalingTarget string, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string)
-	SetDefaultRoute(backend string, scalingTarget string, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string)
-	// DeleteMapping requests that the serverAddress be removed from routes.
+	CreateMapping(serverAddress string, backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string)
+	SetDefaultRoute(backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string)
+	RemoveDefaultRoute()
+	// RemoveMapping requests that the serverAddress be removed from routes.
 	// Returns true if the route existed.
-	DeleteMapping(serverAddress string) bool
+	RemoveMapping(serverAddress string) bool
 }
 
 type RoutesListener interface {
@@ -64,11 +54,11 @@ type IRoutes interface {
 	// The 3rd value returned is the scalingTarget which indicates what endpoint to scale (may differ from backend when using proxy).
 	// The 4th value returned is an (optional) "waker" function which a caller must invoke to wake up serverAddress.
 	// The 5th value returned is an (optional) "sleeper" function which a caller must invoke to shut down serverAddress.
-	FindBackendForServerAddress(ctx context.Context, serverAddress string) (string, string, string, WakerFunc, SleeperFunc)
+	FindBackendForServerAddress(ctx context.Context, serverAddress string) (string, string, ScalingTarget, WakerFunc, SleeperFunc)
 	HasRoute(serverAddress string) bool
-	GetSleepers(scalingTarget string) []SleeperFunc
+	GetSleeper(scalingTarget ScalingTarget) SleeperFunc
 	GetMappings() map[string]string
-	GetDefaultRoute() (string, string, WakerFunc, SleeperFunc)
+	GetDefaultRoute() (string, ScalingTarget, WakerFunc, SleeperFunc)
 	GetAsleepMOTD(serverAddress string) string
 	GetLoadingMOTD(serverAddress string) string
 	SetCountdownDeadline(serverAddress string, deadline time.Time)
@@ -95,7 +85,7 @@ type mapping struct {
 	sleeper           SleeperFunc
 	asleepMOTD        string
 	loadingMOTD       string
-	scalingTarget     string // The endpoint to scale (may differ from backend when using proxy)
+	scalingTarget     ScalingTarget // The endpoint to scale (may differ from backend when using proxy)
 	countdownDeadline time.Time
 }
 
@@ -103,7 +93,7 @@ type routesImpl struct {
 	sync.RWMutex
 	ctx             context.Context
 	mappings        map[string]mapping
-	defaultRoute    mapping
+	defaultRoute    *mapping
 	simplifySRV     bool
 	downScaler      IDownScaler
 	routesListeners []RoutesListener
@@ -126,7 +116,7 @@ func (r *routesImpl) WithListener(listener RoutesListener) IRoutes {
 	for server, backend := range r.mappings {
 		listener.OnRouteAdded(server, backend.backend)
 	}
-	if r.defaultRoute.backend != "" {
+	if r.defaultRoute != nil && r.defaultRoute.backend != "" {
 		listener.OnDefaultRouteSet(r.defaultRoute.backend)
 	}
 	return r
@@ -153,14 +143,11 @@ func (r *routesImpl) Reset() {
 	}
 }
 
-func (r *routesImpl) SetDefaultRoute(backend string, scalingTarget string, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
+func (r *routesImpl) SetDefaultRoute(backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
 	r.Lock()
 	defer r.Unlock()
 
-	if scalingTarget == "" {
-		scalingTarget = backend
-	}
-	r.defaultRoute = mapping{backend: backend, scalingTarget: scalingTarget, waker: waker, sleeper: sleeper, asleepMOTD: asleepMOTD, loadingMOTD: loadingMOTD}
+	r.defaultRoute = &mapping{backend: backend, scalingTarget: scalingTarget, waker: waker, sleeper: sleeper, asleepMOTD: asleepMOTD, loadingMOTD: loadingMOTD}
 
 	logrus.WithFields(logrus.Fields{
 		"backend": backend,
@@ -171,8 +158,21 @@ func (r *routesImpl) SetDefaultRoute(backend string, scalingTarget string, waker
 	}
 }
 
-func (r *routesImpl) GetDefaultRoute() (string, string, WakerFunc, SleeperFunc) {
+func (r *routesImpl) GetDefaultRoute() (string, ScalingTarget, WakerFunc, SleeperFunc) {
 	return r.defaultRoute.backend, r.defaultRoute.scalingTarget, r.defaultRoute.waker, r.defaultRoute.sleeper
+}
+
+func (r *routesImpl) RemoveDefaultRoute() {
+	r.Lock()
+	defer r.Unlock()
+
+	if r.defaultRoute == nil {
+		return
+	}
+
+	for _, listener := range r.routesListeners {
+		listener.OnDefaultRouteRemoved()
+	}
 }
 
 func formatMOTD(motd string, deadline time.Time) string {
@@ -196,6 +196,9 @@ func (r *routesImpl) GetAsleepMOTD(serverAddress string) string {
 	defer r.RUnlock()
 
 	if serverAddress == "" {
+		if r.defaultRoute == nil {
+			return ""
+		}
 		return formatMOTD(r.defaultRoute.asleepMOTD, r.defaultRoute.countdownDeadline)
 	}
 
@@ -211,6 +214,9 @@ func (r *routesImpl) GetLoadingMOTD(serverAddress string) string {
 	defer r.RUnlock()
 
 	if serverAddress == "" {
+		if r.defaultRoute == nil {
+			return ""
+		}
 		return formatMOTD(r.defaultRoute.loadingMOTD, r.defaultRoute.countdownDeadline)
 	}
 
@@ -250,7 +256,7 @@ func (r *routesImpl) HasRoute(serverAddress string) bool {
 	return exists
 }
 
-func (r *routesImpl) FindBackendForServerAddress(_ context.Context, serverAddress string) (string, string, string, WakerFunc, SleeperFunc) {
+func (r *routesImpl) FindBackendForServerAddress(_ context.Context, serverAddress string) (string, string, ScalingTarget, WakerFunc, SleeperFunc) {
 	r.RLock()
 	defer r.RUnlock()
 
@@ -292,23 +298,25 @@ func (r *routesImpl) FindBackendForServerAddress(_ context.Context, serverAddres
 			return mapping.backend, serverAddress, mapping.scalingTarget, mapping.waker, mapping.sleeper
 		}
 	}
-	return r.defaultRoute.backend, serverAddress, r.defaultRoute.scalingTarget, r.defaultRoute.waker, r.defaultRoute.sleeper
+	if r.defaultRoute != nil {
+		return r.defaultRoute.backend, serverAddress, r.defaultRoute.scalingTarget, r.defaultRoute.waker, r.defaultRoute.sleeper
+	}
+	return "", serverAddress, nil, nil, nil
 }
 
-func (r *routesImpl) GetSleepers(scalingTarget string) []SleeperFunc {
+func (r *routesImpl) GetSleeper(scalingTarget ScalingTarget) SleeperFunc {
 	r.RLock()
 	defer r.RUnlock()
 
-	var sleepers []SleeperFunc
 	for _, m := range r.mappings {
-		if m.scalingTarget == scalingTarget && m.sleeper != nil {
-			sleepers = append(sleepers, m.sleeper)
+		if m.scalingTarget.Equal(scalingTarget) && m.sleeper != nil {
+			return m.sleeper
 		}
 	}
-	if r.defaultRoute.scalingTarget == scalingTarget && r.defaultRoute.sleeper != nil {
-		sleepers = append(sleepers, r.defaultRoute.sleeper)
+	if r.defaultRoute != nil && r.defaultRoute.scalingTarget.Equal(scalingTarget) && r.defaultRoute.sleeper != nil {
+		return r.defaultRoute.sleeper
 	}
-	return sleepers
+	return nil
 }
 
 func (r *routesImpl) GetMappings() map[string]string {
@@ -322,7 +330,7 @@ func (r *routesImpl) GetMappings() map[string]string {
 	return result
 }
 
-func (r *routesImpl) DeleteMapping(serverAddress string) bool {
+func (r *routesImpl) RemoveMapping(serverAddress string) bool {
 	r.Lock()
 	defer r.Unlock()
 	logrus.WithField("serverAddress", serverAddress).Info("Deleting route")
@@ -337,20 +345,16 @@ func (r *routesImpl) DeleteMapping(serverAddress string) bool {
 		}
 
 		return true
-	} else {
-		return false
 	}
+
+	return false
 }
 
-func (r *routesImpl) CreateMapping(serverAddress string, backend string, scalingTarget string, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
+func (r *routesImpl) CreateMapping(serverAddress string, backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
 	r.Lock()
 	defer r.Unlock()
 
 	serverAddress = strings.ToLower(serverAddress)
-
-	if scalingTarget == "" {
-		scalingTarget = backend
-	}
 
 	logrus.WithFields(logrus.Fields{
 		"serverAddress": serverAddress,
@@ -362,15 +366,15 @@ func (r *routesImpl) CreateMapping(serverAddress string, backend string, scaling
 		listener.OnRouteAdded(serverAddress, backend)
 	}
 
-	// Trigger auto scale down when mapping is created to ensure servers are shut down if router restarts
-	if r.downScaler != nil && scalingTarget != "" {
+	// Trigger auto-scale down when mapping is created to ensure servers are shut down if router restarts
+	if r.downScaler != nil && scalingTarget != nil {
 		r.downScaler.Start(r.ctx, scalingTarget, r)
 	}
 }
 
 func (r *routesImpl) BulkRegister(scaler *WebhookScaler, mappings map[string]string) {
 	for k, v := range mappings {
-		waker, sleeper := scaler.routeFuncs(k, v)
-		r.CreateMapping(k, v, "", waker, sleeper, "", "")
+		waker, sleeper, scalingTarget := scaler.routeFuncs(k, v)
+		r.CreateMapping(k, v, scalingTarget, waker, sleeper, "", "")
 	}
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -161,6 +161,11 @@ func (r *routesImpl) SetDefaultRoute(backend string, scalingTarget ScalingTarget
 	for _, listener := range r.routesListeners {
 		listener.OnDefaultRouteSet(backend)
 	}
+
+	// Trigger auto-scale down for default route on creation, same as CreateMapping.
+	if r.downScaler != nil && scalingTarget != nil && backend != "" {
+		r.downScaler.Start(r.ctx, scalingTarget, r)
+	}
 }
 
 func (r *routesImpl) GetDefaultRoute() (string, ScalingTarget, WakerFunc, SleeperFunc) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -305,15 +305,19 @@ func (r *routesImpl) FindBackendForServerAddress(_ context.Context, serverAddres
 }
 
 func (r *routesImpl) GetSleeper(scalingTarget ScalingTarget) SleeperFunc {
+	if scalingTarget == nil {
+		return nil
+	}
+
 	r.RLock()
 	defer r.RUnlock()
 
 	for _, m := range r.mappings {
-		if m.scalingTarget.Equal(scalingTarget) && m.sleeper != nil {
+		if m.scalingTarget != nil && m.scalingTarget.ScalingKey() == scalingTarget.ScalingKey() && m.sleeper != nil {
 			return m.sleeper
 		}
 	}
-	if r.defaultRoute != nil && r.defaultRoute.scalingTarget.Equal(scalingTarget) && r.defaultRoute.sleeper != nil {
+	if r.defaultRoute != nil && r.defaultRoute.scalingTarget != nil && r.defaultRoute.scalingTarget.ScalingKey() == scalingTarget.ScalingKey() && r.defaultRoute.sleeper != nil {
 		return r.defaultRoute.sleeper
 	}
 	return nil

--- a/server/routes.go
+++ b/server/routes.go
@@ -388,9 +388,9 @@ func (r *routesImpl) CreateMapping(serverAddress string, backend string, scaling
 	}
 }
 
-// UpdateMapping atomically replaces the backend for an existing route without touching the
-// scale-down timer — the connector owns the timer once a connection is active. When backend
-// is empty (container stopped externally) the timer is cancelled so it doesn't fire needlessly.
+// UpdateMapping atomically replaces the backend for an existing route.
+// It will also cancel the down scaler if backend is now "down" and start the down scaler timer
+// if the backend is now routable but previous mapping entry wasn't, much like CreateMapping
 func (r *routesImpl) UpdateMapping(serverAddress string, backend string, scalingTarget ScalingTarget, waker WakerFunc, sleeper SleeperFunc, asleepMOTD string, loadingMOTD string) {
 	r.Lock()
 	defer r.Unlock()
@@ -401,6 +401,7 @@ func (r *routesImpl) UpdateMapping(serverAddress string, backend string, scaling
 		"serverAddress": serverAddress,
 		"backend":       backend,
 	}).Info("Updated route mapping")
+	prev, hasPrevious := r.mappings[serverAddress]
 	r.mappings[serverAddress] = mapping{backend: backend, scalingTarget: scalingTarget, waker: waker, sleeper: sleeper, asleepMOTD: asleepMOTD, loadingMOTD: loadingMOTD}
 
 	for _, listener := range r.routesListeners {
@@ -408,10 +409,14 @@ func (r *routesImpl) UpdateMapping(serverAddress string, backend string, scaling
 		listener.OnRouteAdded(serverAddress, backend)
 	}
 
-	// Cancel the timer when the backend disappears (container stopped externally).
-	// Don't start a new timer when backend is non-empty — the connector manages that.
-	if r.downScaler != nil && scalingTarget != nil && backend == "" {
-		r.downScaler.Cancel(scalingTarget)
+	if r.downScaler != nil && scalingTarget != nil {
+		// Cancel the timer when the backend disappears (container stopped externally).
+		if backend == "" {
+			r.downScaler.Cancel(scalingTarget)
+			// start timer on a backend transition from down/waking to ready
+		} else if hasPrevious && prev.backend == "" && !scalingTarget.IsScaling() {
+			r.downScaler.Start(r.ctx, scalingTarget, r)
+		}
 	}
 }
 

--- a/server/routes_config_loader.go
+++ b/server/routes_config_loader.go
@@ -53,8 +53,8 @@ func (r *RoutesConfigLoader) Load(routesConfigFileName string) error {
 	}
 
 	r.routes.BulkRegister(r.scaler, config.Mappings)
-	waker, sleeper := r.scaler.routeFuncs("", config.DefaultServer)
-	r.routes.SetDefaultRoute(config.DefaultServer, "", waker, sleeper, "", "")
+	waker, sleeper, scalingTarget := r.scaler.routeFuncs("", config.DefaultServer)
+	r.routes.SetDefaultRoute(config.DefaultServer, scalingTarget, waker, sleeper, "", "")
 	return nil
 }
 
@@ -72,8 +72,8 @@ func (r *RoutesConfigLoader) Reload() error {
 	logrus.WithField("routesConfig", r.fileName).Info("Re-loading routes config file")
 	r.routes.Reset()
 	r.routes.BulkRegister(r.scaler, config.Mappings)
-	waker, sleeper := r.scaler.routeFuncs("", config.DefaultServer)
-	r.routes.SetDefaultRoute(config.DefaultServer, "", waker, sleeper, "", "")
+	waker, sleeper, scalingTarget := r.scaler.routeFuncs("", config.DefaultServer)
+	r.routes.SetDefaultRoute(config.DefaultServer, scalingTarget, waker, sleeper, "", "")
 
 	return nil
 }

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -69,7 +69,7 @@ func Test_routesImpl_FindBackendForServerAddress(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewRoutes(t.Context())
 
-			r.CreateMapping(tt.mapping.serverAddress, tt.mapping.backend, "", nil, nil, "", "")
+			r.CreateMapping(tt.mapping.serverAddress, tt.mapping.backend, nil, nil, nil, "", "")
 
 			if got, server, _, _, _ := r.FindBackendForServerAddress(context.Background(), tt.args.serverAddress); got != tt.want {
 				t.Errorf("routesImpl.FindBackendForServerAddress() = %v, want %v", got, tt.want)
@@ -83,23 +83,17 @@ func Test_routesImpl_FindBackendForServerAddress(t *testing.T) {
 func Test_routesImpl_ScaleKey(t *testing.T) {
 	downScaler := NewDownScaler(false, 1*time.Second)
 
-	t.Run("scaleKey defaults to backend when empty", func(t *testing.T) {
-		r := NewRoutes(t.Context())
-		r.WithDownScaler(downScaler)
-		r.CreateMapping("mc.example.com", "backend:25565", "", nil, nil, "", "")
-
-		_, _, scaleKey, _, _ := r.FindBackendForServerAddress(context.Background(), "mc.example.com")
-		assert.Equal(t, "backend:25565", scaleKey)
-	})
-
+	addressProxy := "proxy:25577"
+	targetProxy := NamedScalingTarget(addressProxy)
+	target5 := NamedScalingTarget("10.0.0.5:25565")
 	t.Run("scaleKey is set when provided", func(t *testing.T) {
 		r := NewRoutes(t.Context())
 		r.WithDownScaler(downScaler)
-		r.CreateMapping("mc.example.com", "proxy:25577", "10.0.0.5:25565", nil, nil, "", "")
+		r.CreateMapping("mc.example.com", addressProxy, target5, nil, nil, "", "")
 
-		backend, _, scaleKey, _, _ := r.FindBackendForServerAddress(context.Background(), "mc.example.com")
-		assert.Equal(t, "proxy:25577", backend)
-		assert.Equal(t, "10.0.0.5:25565", scaleKey)
+		backend, _, scalingTarget, _, _ := r.FindBackendForServerAddress(context.Background(), "mc.example.com")
+		assert.Equal(t, addressProxy, backend)
+		assert.Equal(t, "10.0.0.5:25565", scalingTarget.Key())
 	})
 
 	t.Run("GetSleepers matches on scaleKey not backend", func(t *testing.T) {
@@ -112,52 +106,55 @@ func Test_routesImpl_ScaleKey(t *testing.T) {
 		}
 
 		// Two routes with same proxy backend but different scaleKeys
-		r.CreateMapping("mc1.example.com", "proxy:25577", "10.0.0.1:25565", nil, sleeper, "", "")
-		r.CreateMapping("mc2.example.com", "proxy:25577", "10.0.0.2:25565", nil, nil, "", "")
+		target1 := NamedScalingTarget("10.0.0.1:25565")
+		r.CreateMapping("mc1.example.com", addressProxy, target1, nil, sleeper, "", "")
+		target2 := NamedScalingTarget("10.0.0.2:25565")
+		r.CreateMapping("mc2.example.com", addressProxy, target2, nil, nil, "", "")
 
-		sleepers := r.GetSleepers("10.0.0.1:25565")
-		require.Len(t, sleepers, 1)
-		_ = sleepers[0](context.Background())
+		s := r.GetSleeper(target1)
+		require.NotNil(t, s)
+		// call the sleeper to ensure it's the one registered
+		_ = s(context.Background())
 		assert.True(t, called)
 
 		// No sleeper for the second scaleKey since it has nil sleeper
-		sleepers = r.GetSleepers("10.0.0.2:25565")
-		assert.Empty(t, sleepers)
+		s = r.GetSleeper(target2)
+		assert.Nil(t, s)
 
 		// No sleeper when querying by proxy backend address
-		sleepers = r.GetSleepers("proxy:25577")
-		assert.Empty(t, sleepers)
+		s = r.GetSleeper(targetProxy)
+		assert.Nil(t, s)
 	})
 
 	t.Run("default route scaleKey", func(t *testing.T) {
 		r := NewRoutes(t.Context())
 		r.WithDownScaler(downScaler)
-		r.SetDefaultRoute("proxy:25577", "10.0.0.5:25565", nil, nil, "", "")
+		r.SetDefaultRoute(addressProxy, target5, nil, nil, "", "")
 
-		backend, scaleKey, _, _ := r.GetDefaultRoute()
-		assert.Equal(t, "proxy:25577", backend)
-		assert.Equal(t, "10.0.0.5:25565", scaleKey)
+		backend, scalingTarget, _, _ := r.GetDefaultRoute()
+		assert.Equal(t, addressProxy, backend)
+		assert.True(t, scalingTarget.Equal(target5))
 	})
 
 	t.Run("default route scaleKey defaults to backend", func(t *testing.T) {
 		r := NewRoutes(t.Context())
 		r.WithDownScaler(downScaler)
-		r.SetDefaultRoute("backend:25565", "", nil, nil, "", "")
+		r.SetDefaultRoute("backend:25565", nil, nil, nil, "", "")
 
-		backend, scaleKey, _, _ := r.GetDefaultRoute()
+		backend, scalingTarget, _, _ := r.GetDefaultRoute()
 		assert.Equal(t, "backend:25565", backend)
-		assert.Equal(t, "backend:25565", scaleKey)
+		assert.Nil(t, scalingTarget)
 	})
 }
 
 func Test_routesImpl_LoadingMOTD(t *testing.T) {
 	r := NewRoutes(t.Context())
-	r.CreateMapping("mc.example.com", "backend:25565", "", nil, nil, "asleep", "loading")
+	r.CreateMapping("mc.example.com", "backend:25565", nil, nil, nil, "asleep", "loading")
 
 	assert.Equal(t, "loading", r.GetLoadingMOTD("mc.example.com"))
 	assert.Equal(t, "", r.GetLoadingMOTD("other.example.com"))
 
-	r.SetDefaultRoute("default:25565", "", nil, nil, "default asleep", "default loading")
+	r.SetDefaultRoute("default:25565", nil, nil, nil, "default asleep", "default loading")
 	assert.Equal(t, "default loading", r.GetLoadingMOTD(""))
 }
 
@@ -187,7 +184,7 @@ func TestRoutesListener_OnRouteAdded(t *testing.T) {
 	r := NewRoutes(t.Context()).
 		WithListener(listener)
 
-	r.CreateMapping("mc.example.com", "backend:25565", "", nil, nil, "", "")
+	r.CreateMapping("mc.example.com", "backend:25565", nil, nil, nil, "asleep", "loading")
 
 	listener.AssertCalled(t, "OnRouteAdded", "mc.example.com", "backend:25565")
 }
@@ -200,10 +197,10 @@ func TestRoutesListener_OnRouteRemoved(t *testing.T) {
 		WithListener(listener)
 	r.WithDownScaler(NewDownScaler(false, 5*time.Second))
 
-	r.CreateMapping("mc.example.com", "backend:25565", "", nil, nil, "", "")
+	r.CreateMapping("mc.example.com", "backend:25565", nil, nil, nil, "asleep", "loading")
 	listener.AssertCalled(t, "OnRouteAdded", "mc.example.com", "backend:25565")
 
-	r.DeleteMapping("mc.example.com")
+	r.RemoveMapping("mc.example.com")
 	listener.AssertCalled(t, "OnRouteRemoved", "mc.example.com")
 }
 
@@ -213,7 +210,7 @@ func TestRoutesListener_OnDefaultRouteAdded(t *testing.T) {
 	r := NewRoutes(t.Context()).
 		WithListener(listener)
 
-	r.SetDefaultRoute("default:25565", "", nil, nil, "", "")
+	r.SetDefaultRoute("default:25565", nil, nil, nil, "", "")
 
 	listener.AssertCalled(t, "OnDefaultRouteSet", "default:25565")
 }
@@ -226,10 +223,24 @@ func TestRoutesListener_OnDefaultRouteRemoved_dueToReset(t *testing.T) {
 		WithListener(listener)
 	r.WithDownScaler(NewDownScaler(false, 5*time.Second))
 
-	r.SetDefaultRoute("default:25565", "", nil, nil, "", "")
+	r.SetDefaultRoute("default:25565", nil, nil, nil, "", "")
 	listener.AssertCalled(t, "OnDefaultRouteSet", "default:25565")
 
 	r.Reset()
+	listener.AssertCalled(t, "OnDefaultRouteRemoved")
+}
+
+func TestRoutesListener_OnDefaultRouteRemoved_dueToDeleteDefaultRoute(t *testing.T) {
+	listener := &mockRoutesListener{}
+	listener.On("OnDefaultRouteSet", "default:25565").Return()
+	listener.On("OnDefaultRouteRemoved").Return()
+	r := NewRoutes(t.Context()).
+		WithListener(listener)
+
+	r.SetDefaultRoute("default:25565", nil, nil, nil, "", "")
+	listener.AssertCalled(t, "OnDefaultRouteSet", "default:25565")
+
+	r.RemoveDefaultRoute()
 	listener.AssertCalled(t, "OnDefaultRouteRemoved")
 }
 
@@ -242,7 +253,7 @@ func TestRoutesListener_MultipleListeners(t *testing.T) {
 		WithListener(listener1).
 		WithListener(listener2)
 
-	r.CreateMapping("mc.example.com", "backend:25565", "", nil, nil, "", "")
+	r.CreateMapping("mc.example.com", "backend:25565", nil, nil, nil, "asleep", "loading")
 
 	listener1.AssertCalled(t, "OnRouteAdded", "mc.example.com", "backend:25565")
 	listener2.AssertCalled(t, "OnRouteAdded", "mc.example.com", "backend:25565")
@@ -257,9 +268,9 @@ func TestRoutesListener_ResetCallsOnRouteRemovedForAllRoutes(t *testing.T) {
 		WithListener(listener)
 	r.WithDownScaler(NewDownScaler(false, 5*time.Second))
 
-	r.CreateMapping("mc1.example.com", "backend:25565", "", nil, nil, "", "")
-	r.CreateMapping("mc2.example.com", "backend:25566", "", nil, nil, "", "")
-	r.CreateMapping("mc3.example.com", "backend:25567", "", nil, nil, "", "")
+	r.CreateMapping("mc1.example.com", "backend:25565", nil, nil, nil, "", "")
+	r.CreateMapping("mc2.example.com", "backend:25566", nil, nil, nil, "", "")
+	r.CreateMapping("mc3.example.com", "backend:25567", nil, nil, nil, "", "")
 
 	listener.AssertCalled(t, "OnRouteAdded", "mc1.example.com", "backend:25565")
 	listener.AssertCalled(t, "OnRouteAdded", "mc2.example.com", "backend:25566")
@@ -279,7 +290,7 @@ func TestRoutesListener_DeleteNonExistentRouteDoesNotNotifyListener(t *testing.T
 		WithListener(listener)
 	r.WithDownScaler(NewDownScaler(false, 5*time.Second))
 
-	deleted := r.DeleteMapping("nonexistent.example.com")
+	deleted := r.RemoveMapping("nonexistent.example.com")
 	assert.False(t, deleted)
 
 	listener.AssertNotCalled(t, "OnRouteRemoved", "nonexistent.example.com")
@@ -289,8 +300,8 @@ func TestRoutesListener_NilListenersHandled(t *testing.T) {
 	r := NewRoutes(t.Context())
 	r.WithDownScaler(NewDownScaler(false, 5*time.Second))
 
-	r.CreateMapping("mc.example.com", "backend:25565", "", nil, nil, "", "")
-	r.SetDefaultRoute("default:25565", "", nil, nil, "", "")
-	r.DeleteMapping("mc.example.com")
+	r.CreateMapping("mc.example.com", "backend:25565", nil, nil, nil, "", "")
+	r.SetDefaultRoute("default:25565", nil, nil, nil, "", "")
+	r.RemoveMapping("mc.example.com")
 	r.Reset()
 }

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -80,12 +81,32 @@ func Test_routesImpl_FindBackendForServerAddress(t *testing.T) {
 	}
 }
 
+type testingScalingTarget struct {
+	ScalingIndicator
+	name string
+}
+
+func TestingScalingTarget(name string) ScalingTarget {
+	return &testingScalingTarget{name: name, ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}}}
+}
+
+func (n *testingScalingTarget) String() string {
+	if n == nil {
+		return ""
+	}
+	return n.name
+}
+
+func (n *testingScalingTarget) ScalingKey() string {
+	return n.name
+}
+
 func Test_routesImpl_ScaleKey(t *testing.T) {
 	downScaler := NewDownScaler(false, 1*time.Second)
 
 	addressProxy := "proxy:25577"
-	targetProxy := NamedScalingTarget(addressProxy)
-	target5 := NamedScalingTarget("10.0.0.5:25565")
+	targetProxy := TestingScalingTarget(addressProxy)
+	target5 := TestingScalingTarget("10.0.0.5:25565")
 	t.Run("scaleKey is set when provided", func(t *testing.T) {
 		r := NewRoutes(t.Context())
 		r.WithDownScaler(downScaler)
@@ -93,7 +114,7 @@ func Test_routesImpl_ScaleKey(t *testing.T) {
 
 		backend, _, scalingTarget, _, _ := r.FindBackendForServerAddress(context.Background(), "mc.example.com")
 		assert.Equal(t, addressProxy, backend)
-		assert.Equal(t, "10.0.0.5:25565", scalingTarget.Key())
+		assert.Equal(t, "10.0.0.5:25565", scalingTarget.ScalingKey())
 	})
 
 	t.Run("GetSleepers matches on scaleKey not backend", func(t *testing.T) {
@@ -106,9 +127,9 @@ func Test_routesImpl_ScaleKey(t *testing.T) {
 		}
 
 		// Two routes with same proxy backend but different scaleKeys
-		target1 := NamedScalingTarget("10.0.0.1:25565")
+		target1 := TestingScalingTarget("10.0.0.1:25565")
 		r.CreateMapping("mc1.example.com", addressProxy, target1, nil, sleeper, "", "")
-		target2 := NamedScalingTarget("10.0.0.2:25565")
+		target2 := TestingScalingTarget("10.0.0.2:25565")
 		r.CreateMapping("mc2.example.com", addressProxy, target2, nil, nil, "", "")
 
 		s := r.GetSleeper(target1)
@@ -133,7 +154,7 @@ func Test_routesImpl_ScaleKey(t *testing.T) {
 
 		backend, scalingTarget, _, _ := r.GetDefaultRoute()
 		assert.Equal(t, addressProxy, backend)
-		assert.True(t, scalingTarget.Equal(target5))
+		assert.Equal(t, target5.ScalingKey(), scalingTarget.ScalingKey())
 	})
 
 	t.Run("default route scaleKey defaults to backend", func(t *testing.T) {

--- a/server/scaling_target.go
+++ b/server/scaling_target.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+type ScalingTarget interface {
+	fmt.Stringer
+	// IsScaling returns true if the target is currently scaling up or down
+	IsScaling() bool
+	// StartScaling and EndScaling are called when the target starts and stops scaling. Returns true if this is the first state change.
+	StartScaling() bool
+	EndScaling() bool
+	Equal(other ScalingTarget) bool
+	// Key returns a unique identifier for the target or "" if the instance is nil
+	Key() string
+}
+
+type ScalingIndicator struct {
+	scaling *atomic.Bool
+}
+
+func (i *ScalingIndicator) IsScaling() bool {
+	return i.scaling.Load()
+}
+
+func (i *ScalingIndicator) StartScaling() bool {
+	return i.scaling.CompareAndSwap(false, true)
+}
+
+func (i *ScalingIndicator) EndScaling() bool {
+	return i.scaling.CompareAndSwap(true, false)
+}
+
+type namedScalingTarget struct {
+	ScalingIndicator
+	name string
+}
+
+func NamedScalingTarget(name string) ScalingTarget {
+	return &namedScalingTarget{name: name, ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}}}
+}
+
+func (n *namedScalingTarget) String() string {
+	if n == nil {
+		return ""
+	}
+	return n.name
+}
+
+func (n *namedScalingTarget) Key() string {
+	if n == nil {
+		return ""
+	}
+	return n.name
+}
+
+func (n *namedScalingTarget) Equal(other ScalingTarget) bool {
+	if n == nil || other == nil {
+		return n == nil && other == nil
+	}
+	if otherNamed, ok := other.(*namedScalingTarget); ok {
+		return n.name == otherNamed.name
+	}
+	return false
+}

--- a/server/scaling_target.go
+++ b/server/scaling_target.go
@@ -1,28 +1,25 @@
 package server
 
 import (
-	"fmt"
 	"sync/atomic"
 )
 
 type ScalingTarget interface {
-	fmt.Stringer
-	// IsScaling returns true if the target is currently scaling up or down
-	IsScaling() bool
-	// StartScaling and EndScaling are called when the target starts and stops scaling. Returns true if this is the first state change.
+	// StartScaling and EndScaling are called when the target scales up (via WakerFunc) and scales down (via SleeperFunc).
+	// Returns true if this is the first state change, which is intended to be used in a guarded conditional such as
+	//
+	// 	if scalingTarget.StartScaling() {
+	//    defer scalingTarget.EndScaling()
+	//    // invoke sleeper/waker
+	// 	}
 	StartScaling() bool
 	EndScaling() bool
-	Equal(other ScalingTarget) bool
-	// Key returns a unique identifier for the target or "" if the instance is nil
-	Key() string
+	// ScalingKey returns a unique identifier for the target suitable for use as a map key.
+	ScalingKey() string
 }
 
 type ScalingIndicator struct {
 	scaling *atomic.Bool
-}
-
-func (i *ScalingIndicator) IsScaling() bool {
-	return i.scaling.Load()
 }
 
 func (i *ScalingIndicator) StartScaling() bool {
@@ -31,37 +28,4 @@ func (i *ScalingIndicator) StartScaling() bool {
 
 func (i *ScalingIndicator) EndScaling() bool {
 	return i.scaling.CompareAndSwap(true, false)
-}
-
-type namedScalingTarget struct {
-	ScalingIndicator
-	name string
-}
-
-func NamedScalingTarget(name string) ScalingTarget {
-	return &namedScalingTarget{name: name, ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}}}
-}
-
-func (n *namedScalingTarget) String() string {
-	if n == nil {
-		return ""
-	}
-	return n.name
-}
-
-func (n *namedScalingTarget) Key() string {
-	if n == nil {
-		return ""
-	}
-	return n.name
-}
-
-func (n *namedScalingTarget) Equal(other ScalingTarget) bool {
-	if n == nil || other == nil {
-		return n == nil && other == nil
-	}
-	if otherNamed, ok := other.(*namedScalingTarget); ok {
-		return n.name == otherNamed.name
-	}
-	return false
 }

--- a/server/scaling_target.go
+++ b/server/scaling_target.go
@@ -16,6 +16,7 @@ type ScalingTarget interface {
 	EndScaling() bool
 	// ScalingKey returns a unique identifier for the target suitable for use as a map key.
 	ScalingKey() string
+	IsScaling() bool
 }
 
 type ScalingIndicator struct {
@@ -24,6 +25,10 @@ type ScalingIndicator struct {
 
 func (i *ScalingIndicator) StartScaling() bool {
 	return i.scaling.CompareAndSwap(false, true)
+}
+
+func (i *ScalingIndicator) IsScaling() bool {
+	return i.scaling.Load()
 }
 
 func (i *ScalingIndicator) EndScaling() bool {

--- a/server/server.go
+++ b/server/server.go
@@ -55,10 +55,13 @@ func NewServer(ctx context.Context, config *Config) (*Server, error) {
 	webhookScalerConfigured := config.AutoScale.Webhook.Url != ""
 	downScalerEnabled := (config.AutoScale.Down && (config.InKubeCluster || config.KubeConfig != "" || config.InDocker || config.InDockerSwarm)) || webhookScalerConfigured
 	downScalerDelay := config.AutoScale.DownAfter
-	// Only one instance should be created
-	// TODO why create it if not enabled? nil checks needed if optional
-	downscaler := NewDownScaler(downScalerEnabled, downScalerDelay)
-	routes.WithDownScaler(downscaler)
+	var downscaler IDownScaler
+	if downScalerEnabled {
+		downscaler = NewDownScaler(downScalerEnabled, downScalerDelay)
+		routes.WithDownScaler(downscaler)
+
+		downscaler.HandleContextDone(ctx)
+	}
 
 	// Build the webhook scaler and hand it to the objects that register static
 	// routes so they pick up its waker/sleeper. Discovery-based routes

--- a/server/server.go
+++ b/server/server.go
@@ -94,8 +94,8 @@ func NewServer(ctx context.Context, config *Config) (*Server, error) {
 
 	routes.BulkRegister(webhookScaler, config.Mapping)
 	if config.Default != "" {
-		waker, sleeper := webhookScaler.routeFuncs("", config.Default)
-		routes.SetDefaultRoute(config.Default, "", waker, sleeper, "", "")
+		waker, sleeper, scalingTarget := webhookScaler.routeFuncs("", config.Default)
+		routes.SetDefaultRoute(config.Default, scalingTarget, waker, sleeper, "", "")
 	}
 
 	if config.ConnectionRateLimit < 1 {

--- a/server/webhook_scaler.go
+++ b/server/webhook_scaler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -62,6 +63,13 @@ type WebhookScalingTarget struct {
 	backend string
 }
 
+func NewWebhookScalingTarget(backend string) *WebhookScalingTarget {
+	return &WebhookScalingTarget{
+		ScalingIndicator: ScalingIndicator{scaling: &atomic.Bool{}},
+		backend:          backend,
+	}
+}
+
 func (t *WebhookScalingTarget) String() string {
 	if t == nil {
 		return ""
@@ -79,7 +87,7 @@ func (s *WebhookScaler) routeFuncs(serverAddress string, backend string) (WakerF
 	if s == nil || s.url == "" {
 		return nil, nil, nil
 	}
-	return s.makeWakerFunc(serverAddress, backend), s.makeSleeperFunc(serverAddress, backend), &WebhookScalingTarget{backend: backend}
+	return s.makeWakerFunc(serverAddress, backend), s.makeSleeperFunc(serverAddress, backend), NewWebhookScalingTarget(backend)
 }
 
 func (s *WebhookScaler) makeWakerFunc(serverAddress string, backend string) WakerFunc {

--- a/server/webhook_scaler.go
+++ b/server/webhook_scaler.go
@@ -108,10 +108,7 @@ func (s *WebhookScaler) makeWakerFunc(serverAddress string, backend string) Wake
 				"override":          override,
 			}).Debug("Using backend address from scale-up response")
 		}
-		if err := s.waitForBackendReachable(ctx, effectiveBackend, s.wakeTimeout); err != nil {
-			return effectiveBackend, err
-		}
-		return effectiveBackend, nil
+		return waitForBackend(ctx, effectiveBackend, s.wakeTimeout)
 	}
 }
 

--- a/server/webhook_scaler.go
+++ b/server/webhook_scaler.go
@@ -69,35 +69,21 @@ func (t *WebhookScalingTarget) String() string {
 	return t.backend
 }
 
-func (t *WebhookScalingTarget) Equal(other ScalingTarget) bool {
-	if t == nil || other == nil {
-		return t == nil && other == nil
-	}
-	otherTarget, ok := other.(*WebhookScalingTarget)
-	if !ok {
-		return false
-	}
-	return t.Key() == otherTarget.Key()
-}
-
-func (t *WebhookScalingTarget) Key() string {
-	if t == nil {
-		return ""
-	}
+func (t *WebhookScalingTarget) ScalingKey() string {
 	return t.backend
 }
 
 // routeFuncs returns the waker/sleeper pair for a static route. It is nil-safe
 // so callers can invoke it on an unconfigured (nil) scaler.
 func (s *WebhookScaler) routeFuncs(serverAddress string, backend string) (WakerFunc, SleeperFunc, ScalingTarget) {
-	if s == nil {
+	if s == nil || s.url == "" {
 		return nil, nil, nil
 	}
 	return s.makeWakerFunc(serverAddress, backend), s.makeSleeperFunc(serverAddress, backend), &WebhookScalingTarget{backend: backend}
 }
 
 func (s *WebhookScaler) makeWakerFunc(serverAddress string, backend string) WakerFunc {
-	if s.url == "" {
+	if s == nil || s.url == "" {
 		return nil
 	}
 	return func(ctx context.Context) (string, error) {

--- a/server/webhook_scaler.go
+++ b/server/webhook_scaler.go
@@ -57,13 +57,43 @@ func NewWebhookScaler(url string, headers map[string]string, requestTimeout time
 	}
 }
 
+type WebhookScalingTarget struct {
+	ScalingIndicator
+	backend string
+}
+
+func (t *WebhookScalingTarget) String() string {
+	if t == nil {
+		return ""
+	}
+	return t.backend
+}
+
+func (t *WebhookScalingTarget) Equal(other ScalingTarget) bool {
+	if t == nil || other == nil {
+		return t == nil && other == nil
+	}
+	otherTarget, ok := other.(*WebhookScalingTarget)
+	if !ok {
+		return false
+	}
+	return t.Key() == otherTarget.Key()
+}
+
+func (t *WebhookScalingTarget) Key() string {
+	if t == nil {
+		return ""
+	}
+	return t.backend
+}
+
 // routeFuncs returns the waker/sleeper pair for a static route. It is nil-safe
 // so callers can invoke it on an unconfigured (nil) scaler.
-func (s *WebhookScaler) routeFuncs(serverAddress string, backend string) (WakerFunc, SleeperFunc) {
+func (s *WebhookScaler) routeFuncs(serverAddress string, backend string) (WakerFunc, SleeperFunc, ScalingTarget) {
 	if s == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
-	return s.makeWakerFunc(serverAddress, backend), s.makeSleeperFunc(serverAddress, backend)
+	return s.makeWakerFunc(serverAddress, backend), s.makeSleeperFunc(serverAddress, backend), &WebhookScalingTarget{backend: backend}
 }
 
 func (s *WebhookScaler) makeWakerFunc(serverAddress string, backend string) WakerFunc {

--- a/server/webhook_scaler_test.go
+++ b/server/webhook_scaler_test.go
@@ -160,7 +160,8 @@ func TestWebhookScaler_ErrorOnNon2xx(t *testing.T) {
 
 func TestWebhookScaler_RouteFuncsNilSafe(t *testing.T) {
 	var scaler *WebhookScaler // unconfigured
-	waker, sleeper := scaler.routeFuncs("mc.example.com", "10.0.0.5:25565")
+	waker, sleeper, scalingTarget := scaler.routeFuncs("mc.example.com", "10.0.0.5:25565")
 	assert.Nil(t, waker)
 	assert.Nil(t, sleeper)
+	assert.Nil(t, scalingTarget)
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,7 +5,8 @@ metadata:
   name: mc-router-dev
 build:
   artifacts:
-  - image: itzg/mc-router-dev
+    # image needs to match the image used in manifests/rawYaml below
+  - image: itzg/mc-router
     # https://skaffold.dev/docs/pipeline-stages/builders/ko/
     ko:
       main: ./cmd/mc-router/

--- a/test/docker-discovery/compose.yml
+++ b/test/docker-discovery/compose.yml
@@ -12,6 +12,11 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     # Matches MCs below
     network_mode: bridge
+    # If getting "Permission denied" errors for the docker socket
+    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
+    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
+    user: ":999"
+
   vanilla:
     image: itzg/minecraft-server
     environment:

--- a/test/docker-discovery/compose.yml
+++ b/test/docker-discovery/compose.yml
@@ -12,10 +12,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     # Matches MCs below
     network_mode: bridge
-    # If getting "Permission denied" errors for the docker socket
-    # change this group ID to match your system. Group ID 999 is the default for Docker Desktop's VM.
-    # Find the group ID by using `stat -c '%g' /var/run/docker.sock` on your host
-    user: ":999"
+    # Refer to the "User access to docker socket" section in the README
+    group_add:
+      - "0"
 
   vanilla:
     image: itzg/minecraft-server


### PR DESCRIPTION
- correctly handle down scaling when a docker service has multiple external hosts
- introduce ScalingTarget interface with types for docker, swarm, k8s, and webhook discovery/scaling
- clean up code for scale down timer
- avoid race conditions like scale down timer start during wake
- better k8s and docker object logging
- use cgr.dev/chainguard/static as base image
  - **NOTE** the image now runs mc-router as a non-root user by default
- Use avast/retry-go for k8s backend readiness check
- Fix skaffold image reference
- Document manual docker test case (pending a simulated test client)
- Better debug logs in general
- Modern Go cleanup

TODO
- [x] Testing on Swarm
- [x] Testing of webhook scaler