### PR TITLE
Specify deployment constraints in compose file for docker swarm example

### DIFF
--- a/examples/swarm/compose.yml
+++ b/examples/swarm/compose.yml
@@ -11,6 +11,10 @@ services:
       TASKS: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
     networks:
       - minecraft
 


### PR DESCRIPTION
Missed a gotcha with Swarm that will lead to instant crashing unless this is specified.