### PR TITLE
Fix nil pointer dereference when deleting route without downscaler

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -351,7 +351,9 @@ func (r *routesImpl) RemoveMapping(serverAddress string) bool {
 
 	serverAddress = strings.ToLower(serverAddress)
 	if m, ok := r.mappings[serverAddress]; ok {
-		r.downScaler.Cancel(m.scalingTarget)
+		if r.downScaler != nil {
+			r.downScaler.Cancel(m.scalingTarget)
+		}
 		delete(r.mappings, serverAddress)
 
 		for _, listener := range r.routesListeners {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -225,6 +225,22 @@ func TestRoutesListener_OnRouteRemoved(t *testing.T) {
 	listener.AssertCalled(t, "OnRouteRemoved", "mc.example.com")
 }
 
+func TestRoutesListener_OnRouteRemoved_withoutDownScaler(t *testing.T) {
+	listener := &mockRoutesListener{}
+	listener.On("OnRouteAdded", "mc.example.com", "backend:25565").Return()
+	listener.On("OnRouteRemoved", "mc.example.com").Return()
+
+	r := NewRoutes(t.Context()).
+		WithListener(listener)
+	r.WithDownScaler(nil)
+
+	r.CreateMapping("mc.example.com", "backend:25565", TestingScalingTarget("mc.example.com"), nil, nil, "", "")
+
+	assert.True(t, r.RemoveMapping("mc.example.com"))
+	listener.AssertCalled(t, "OnRouteRemoved", "mc.example.com")
+	assert.False(t, r.HasRoute("mc.example.com"))
+}
+
 func TestRoutesListener_OnDefaultRouteAdded(t *testing.T) {
 	listener := &mockRoutesListener{}
 	listener.On("OnDefaultRouteSet", "default:25565").Return()


### PR DESCRIPTION
Hi @itzg!

I ran into the panic below when a route is removed and auto downscaling is not enabled. This PR fixes that.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xb8af54]

goroutine 10 [running]:
testing.tRunner.func1.2({0xcef100, 0x18a01b0})
	/usr/local/go/src/testing/testing.go:1974 +0x1a0
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1977 +0x318
panic({0xcef100?, 0x18a01b0?})
	/usr/local/go/src/runtime/panic.go:860 +0x12c
github.com/itzg/mc-router/server.(*routesImpl).RemoveMapping(0x90552cfeb60, {0xee177b, 0xe})
	/workspaces/mc-router/server/routes.go:355 +0x164
github.com/itzg/mc-router/server.TestRoutesListener_OnRouteRemoved_withoutDownScaler(0x90552dc8248)
	/workspaces/mc-router/server/routes_test.go:239 +0x224
testing.tRunner(0x90552dc8248, 0xf93120)
	/usr/local/go/src/testing/testing.go:2036 +0xc4
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:2101 +0x3a8
```