### PR TITLE
Avoid rearming scale-down timer on route reload

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -376,16 +376,19 @@ func (r *routesImpl) CreateMapping(serverAddress string, backend string, scaling
 		"serverAddress": serverAddress,
 		"backend":       backend,
 	}).Info("Created route mapping")
+	previous, hasPrevious := r.mappings[serverAddress]
 	r.mappings[serverAddress] = mapping{backend: backend, scalingTarget: scalingTarget, waker: waker, sleeper: sleeper, asleepMOTD: asleepMOTD, loadingMOTD: loadingMOTD}
 
 	for _, listener := range r.routesListeners {
 		listener.OnRouteAdded(serverAddress, backend)
 	}
 
-	// Trigger auto-scale down when mapping is created to ensure servers are shut down if router restarts.
-	// Only start the timer when backend is non-empty — an empty backend means the server is already
-	// asleep/stopped (e.g. a Docker stop event updated the route), so there is nothing to scale down.
-	if r.downScaler != nil && scalingTarget != nil && backend != "" {
+	// Trigger auto-scale down when a mapping first makes a scaling target routable to ensure servers
+	// are shut down if the router restarts. Re-registering an already-routable target must preserve
+	// its timer state since an active connection may have cancelled the timer in the meantime.
+	shouldStartDownTimer := scalingTarget != nil && (!hasPrevious || previous.backend == "" || previous.scalingTarget == nil ||
+		previous.scalingTarget.ScalingKey() != scalingTarget.ScalingKey())
+	if r.downScaler != nil && backend != "" && shouldStartDownTimer {
 		r.downScaler.Start(r.ctx, scalingTarget, r)
 	}
 }

--- a/server/routes_config_reload_test.go
+++ b/server/routes_config_reload_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/itzg/mc-router/mcproto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRouteConfigReloadDoesNotScaleDownActiveConnection(t *testing.T) {
+	const scaleDownDelay = 500 * time.Millisecond
+	const serverAddress = "mc.example.com"
+
+	downScaler := NewDownScaler(true, scaleDownDelay)
+	routes := NewRoutes(t.Context()).WithDownScaler(downScaler)
+	target := TestingScalingTarget("reload-test-backend")
+	var connector *Connector
+	scaleDownCalled := make(chan int, 1)
+	sleeper := func(context.Context) error {
+		scaleDownCalled <- connector.scaleActiveConnections.GetCount(target.ScalingKey())
+		return nil
+	}
+
+	backendListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = backendListener.Close() })
+
+	backendConnection := make(chan net.Conn, 1)
+	go func() {
+		conn, acceptErr := backendListener.Accept()
+		if acceptErr == nil {
+			backendConnection <- conn
+		}
+	}()
+
+	backendAddress := backendListener.Addr().String()
+	routes.CreateMapping(serverAddress, backendAddress, target, nil, sleeper, "", "")
+
+	connector = NewConnector(
+		t.Context(),
+		routes,
+		downScaler,
+		discardMetricsBuilder{}.BuildConnectorMetrics(),
+		false,
+		false,
+		nil,
+	)
+
+	frontendListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = frontendListener.Close() })
+	go connector.acceptConnections(frontendListener, 100, 0)
+
+	clientConnection, err := net.Dial("tcp", frontendListener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientConnection.Close() })
+
+	require.NoError(t, writeTestPacket(clientConnection, 0x00, func(w io.Writer) {
+		_ = mcproto.WriteVarInt(w, int32(mcproto.ProtocolVersion1_18_2))
+		_ = mcproto.WriteString(w, serverAddress)
+		_, _ = w.Write([]byte{0x63, 0xdd})
+		_ = mcproto.WriteVarInt(w, int32(mcproto.StateLogin))
+	}))
+	require.NoError(t, writeTestPacket(clientConnection, 0x00, func(w io.Writer) {
+		_ = mcproto.WriteString(w, "RouteReloadTest")
+	}))
+
+	var acceptedBackendConnection net.Conn
+	select {
+	case acceptedBackendConnection = <-backendConnection:
+		t.Cleanup(func() { _ = acceptedBackendConnection.Close() })
+	case <-time.After(2 * time.Second):
+		t.Fatal("router did not connect to test backend")
+	}
+
+	require.Eventually(t, func() bool {
+		return connector.scaleActiveConnections.GetCount(target.ScalingKey()) == 1
+	}, 2*time.Second, 10*time.Millisecond, "test connection never became active")
+
+	// RoutesConfigLoader.Load calls BulkRegister after a watched file change,
+	// which calls CreateMapping again for this unchanged, already-active route.
+	routes.CreateMapping(serverAddress, backendAddress, target, nil, sleeper, "", "")
+
+	select {
+	case activeConnections := <-scaleDownCalled:
+		t.Fatalf("scale-down sleeper ran with %d active backend connection(s)", activeConnections)
+	case <-time.After(2 * scaleDownDelay):
+	}
+}


### PR DESCRIPTION
## What changed

- preserve scale-down timer state when an already-routable scaling target is re-registered
- add an end-to-end regression test with a real proxied Minecraft login connection

## Why

Watched routes are reloaded through `CreateMapping`. That method always started a scale-down timer, even when the same scaling target was already routable. If an active connection had previously cancelled the timer, reloading the routes file silently re-armed it and allowed the backend to be stopped beneath the connected player.

The timer now starts only when a mapping first makes a scaling target routable, when the previous mapping was down, or when the scaling target changes.

## Impact

Reloading a watched routes file no longer makes an actively used backend eligible for scale-down. Initial registrations and down-to-ready transitions continue to receive their idle timer.

## Validation

- `go test ./...`
- `go test -race ./server`
- `go test ./server -run '^TestRouteConfigReloadDoesNotScaleDownActiveConnection$' -count=10`

Fixes #594
