### PR TITLE
fix: nil default route panic when saving routes with no config file

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -169,6 +169,9 @@ func (r *routesImpl) SetDefaultRoute(backend string, scalingTarget ScalingTarget
 }
 
 func (r *routesImpl) GetDefaultRoute() (string, ScalingTarget, WakerFunc, SleeperFunc) {
+	if r.defaultRoute == nil {
+		return "", nil, nil, nil
+	}
 	return r.defaultRoute.backend, r.defaultRoute.scalingTarget, r.defaultRoute.waker, r.defaultRoute.sleeper
 }
 
@@ -242,7 +245,9 @@ func (r *routesImpl) SetCountdownDeadline(serverAddress string, deadline time.Ti
 	defer r.Unlock()
 
 	if serverAddress == "" {
-		r.defaultRoute.countdownDeadline = deadline
+		if r.defaultRoute != nil {
+			r.defaultRoute.countdownDeadline = deadline
+		}
 		return
 	}
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -453,3 +453,24 @@ func (m *MockRoutes) WithListener(listener RoutesListener) IRoutes {
 	args := m.MethodCalled("WithListener", listener)
 	return args.Get(0).(IRoutes)
 }
+
+func Test_routesImpl_GetDefaultRouteWithoutDefaultRoute(t *testing.T) {
+	// A fresh instance (no config file read, no default route set yet) must
+	// not panic when the routes config loader saves on the first API route
+	// creation (#603).
+	routes := NewRoutes(context.Background())
+
+	backend, scalingTarget, waker, sleeper := routes.GetDefaultRoute()
+	assert.Empty(t, backend)
+	assert.Nil(t, scalingTarget)
+	assert.Nil(t, waker)
+	assert.Nil(t, sleeper)
+}
+
+func Test_routesImpl_SetCountdownDeadlineWithoutDefaultRoute(t *testing.T) {
+	routes := NewRoutes(context.Background())
+
+	require.NotPanics(t, func() {
+		routes.SetCountdownDeadline("", time.Now().Add(time.Minute))
+	})
+}


### PR DESCRIPTION
Fixes #603.

## Root cause

With `ROUTES_CONFIG` pointing at a file that does not exist yet (fresh docker volume), `RoutesConfigLoader.Load` logs "Routes config file doses not exist, skipping reading it" and returns early — **without** the `SetDefaultRoute` call it makes when the file exists. `routesImpl.defaultRoute` therefore stays `nil`.

The first route added via the REST API (`routesCreateHandler`) calls `RoutesConfigLoader.SaveRoutes` → `routes.GetDefaultRoute()`, which unconditionally dereferences `r.defaultRoute` — panicking the HTTP handler with the nil pointer dereference from the report.

`SetCountdownDeadline("")` had the same unguarded `r.defaultRoute` assignment.

## Fix

- `GetDefaultRoute` returns zero values (`"", nil, nil, nil`) when no default route is set;
- `SetCountdownDeadline` skips the assignment for the default route in that state.

## Testing

Added to `server/routes_test.go`:

- `Test_routesImpl_GetDefaultRouteWithoutDefaultRoute` — a fresh `NewRoutes` instance reports an empty default route without panicking;
- `Test_routesImpl_SetCountdownDeadlineWithoutDefaultRoute` — same for the countdown deadline assignment.

Differential: on unpatched `routes.go` the first test fails with `panic: runtime error: invalid memory address or nil pointer dereference` (the exact report); with the fix the full `./server/` suite passes (`go test ./server/ -count=1` → ok).
