### PR TITLE
Abstract ConnectionMetrics to allow for provider switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Wakers/sleepers (`WakerFunc`/`SleeperFunc` in `routes.go`) are attached per rout
 ### Concurrency Model
 
 - **`routes.go`**: global singleton `var Routes = NewRoutes()`. `sync.RWMutex` protects `mappings` and `defaultRoute` — `RLock` for all reads, `Lock` for mutations.
-- **`connector.go`**: `ActiveConnections` map guarded by `sync.RWMutex`; `totalActiveConnections` counter uses `atomic.AddInt32`. Shutdown drain uses `sync.Cond` in `WaitForConnections()`.
+- **`connector.go`**: `totalActiveConnections` counter uses `atomic.AddInt32`. Shutdown drain uses `sync.Cond` in `WaitForConnections()`.
 - **Bidirectional proxy**: two goroutines per connection (client→backend, backend→client) communicate via a buffered `chan error` (size 2) — first error triggers mutual close.
 - All goroutines respect context cancellation via `select { case <-ctx.Done() }`.
 

--- a/docs/metrics.http
+++ b/docs/metrics.http
@@ -1,0 +1,4 @@
+### GET request to example server
+GET localhost:8080/metrics
+
+###

--- a/server/connector.go
+++ b/server/connector.go
@@ -88,7 +88,7 @@ func (sm *ActiveConnections) GetCount(backendAddress string) int {
 	return 0
 }
 
-func NewConnector(ctx context.Context, routes IRoutes, downScaler IDownScaler, metrics *ConnectorMetrics, sendProxyProto bool, recordLogins bool, autoScaleUpAllowDenyConfig *AllowDenyConfig) *Connector {
+func NewConnector(ctx context.Context, routes IRoutes, downScaler IDownScaler, metrics ConnectorMetrics, sendProxyProto bool, recordLogins bool, autoScaleUpAllowDenyConfig *AllowDenyConfig) *Connector {
 
 	return &Connector{
 		ctx:                        ctx,
@@ -128,7 +128,7 @@ type Connector struct {
 	routes IRoutes
 	// downScaler is used to scale up and down the number of backend connections. nil if disabled.
 	downScaler                 IDownScaler
-	metrics                    *ConnectorMetrics
+	metrics                    ConnectorMetrics
 	sendProxyProto             bool
 	receiveProxyProto          bool
 	recordLogins               bool

--- a/server/connector.go
+++ b/server/connector.go
@@ -278,13 +278,13 @@ func (c *Connector) bucketMetrics(bucket *ratelimit.Bucket, period time.Duration
 		case <-c.ctx.Done():
 			return
 		case <-ticker.C:
-			c.metrics.RateLimitAvailable.Set(float64(bucket.Available()))
+			c.metrics.SetRateLimitAvailable(bucket.Available())
 		}
 	}
 }
 
 func (c *Connector) HandleConnection(frontendConn net.Conn) {
-	c.metrics.ConnectionsFrontend.Add(1)
+	c.metrics.IncrementConnectionsFrontend()
 	//noinspection GoUnhandledErrorResult
 	defer frontendConn.Close()
 
@@ -318,13 +318,13 @@ func (c *Connector) HandleConnection(frontendConn net.Conn) {
 			WithError(err).
 			WithField("client", clientAddr).
 			Error("Failed to set read deadline")
-		c.metrics.Errors.With("type", "read_deadline").Add(1)
+		c.metrics.IncrementErrors("read_deadline")
 		return
 	}
 	packet, err := mcproto.ReadPacket(bufferedReader, clientAddr, c.state)
 	if err != nil {
 		logrus.WithError(err).WithField("clientAddr", clientAddr).Error("Failed to read packet")
-		c.metrics.Errors.With("type", "read").Add(1)
+		c.metrics.IncrementErrors("read")
 		return
 	}
 
@@ -339,7 +339,7 @@ func (c *Connector) HandleConnection(frontendConn net.Conn) {
 		if err != nil {
 			logrus.WithError(err).WithField("clientAddr", clientAddr).
 				Error("Failed to read handshake")
-			c.metrics.Errors.With("type", "read").Add(1)
+			c.metrics.IncrementErrors("read")
 			return
 		}
 
@@ -363,7 +363,7 @@ func (c *Connector) HandleConnection(frontendConn net.Conn) {
 						WithError(err).
 						WithField("clientAddr", clientAddr).
 						Error("Failed to read user info")
-					c.metrics.Errors.With("type", "read").Add(1)
+					c.metrics.IncrementErrors("read")
 					return
 				}
 			}
@@ -382,7 +382,7 @@ func (c *Connector) HandleConnection(frontendConn net.Conn) {
 				WithField("client", clientAddr).
 				WithField("packet", packet).
 				Warn("Unexpected data type for PacketIdLegacyServerListPing")
-			c.metrics.Errors.With("type", "unexpected_content").Add(1)
+			c.metrics.IncrementErrors("unexpected_content")
 			return
 		}
 
@@ -399,7 +399,7 @@ func (c *Connector) HandleConnection(frontendConn net.Conn) {
 			WithField("client", clientAddr).
 			WithField("packetID", packet.PacketID).
 			Error("Unexpected packetID, expected handshake")
-		c.metrics.Errors.With("type", "unexpected_content").Add(1)
+		c.metrics.IncrementErrors("unexpected_content")
 		return
 	}
 }
@@ -559,24 +559,21 @@ func (c *Connector) cleanupBackendConnection(
 	}
 
 	if cleanupMetrics {
-		c.metrics.ActiveConnections.Set(float64(
-			atomic.AddInt32(&c.totalActiveConnections, -1)))
+		c.metrics.SetActiveConnections(atomic.AddInt32(&c.totalActiveConnections, -1))
 
 		c.activeConnections.Decrement(backendHostPort)
-		c.metrics.ServerActiveConnections.
-			With("server_address", sanitizeUTF8(serverAddress)).
-			Set(float64(c.activeConnections.GetCount(backendHostPort)))
+		c.metrics.SetServerActiveConnections(sanitizeUTF8(serverAddress), c.activeConnections.GetCount(backendHostPort))
 
 		if scalingTarget != nil {
 			c.scaleActiveConnections.Decrement(scalingTarget.ScalingKey())
 		}
 
 		if c.recordLogins && playerInfo != nil {
-			c.metrics.ServerActivePlayer.
-				With("player_name", sanitizeUTF8(playerInfo.Name)).
-				With("player_uuid", sanitizeUTF8(playerInfo.Uuid.String())).
-				With("server_address", sanitizeUTF8(serverAddress)).
-				Set(0)
+			c.metrics.SetServerActivePlayerCounts(
+				sanitizeUTF8(playerInfo.Name),
+				sanitizeUTF8(playerInfo.Uuid.String()),
+				sanitizeUTF8(serverAddress),
+				0)
 		}
 	}
 	logrus.
@@ -636,12 +633,12 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			c.wakingServers.Decrement(serverAddress)
 			if err != nil {
 				logrus.WithFields(logrus.Fields{"serverAddress": serverAddress}).WithError(err).Error("failed to wake up backend")
-				c.metrics.Errors.With("type", "wakeup_failed").Add(1)
+				c.metrics.IncrementErrors("wakeup_failed")
 				return
 			}
 			if newBackendHostPort == "" {
 				logrus.WithFields(logrus.Fields{"serverAddress": serverAddress}).Warn("waker did not return a backend address")
-				c.metrics.Errors.With("type", "wakeup_no_address").Add(1)
+				c.metrics.IncrementErrors("wakeup_no_address")
 				return
 			}
 			backendHostPort = newBackendHostPort
@@ -659,7 +656,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 				WithField("resolvedHost", resolvedHost).
 				WithField("player", playerInfo).
 				Warn("Unable to find registered backend")
-			c.metrics.Errors.With("type", "missing_backend").Add(1)
+			c.metrics.IncrementErrors("missing_backend")
 		}
 
 		if c.connectionNotifier != nil {
@@ -719,7 +716,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			WithField("backend", backendHostPort).
 			WithField("player", playerInfo).
 			Warn("Unable to connect to backend")
-		c.metrics.Errors.With("type", "backend_failed").Add(1)
+		c.metrics.IncrementErrors("backend_failed")
 
 		if waker != nil {
 			logrus.WithField("serverAddress", serverAddress).
@@ -762,10 +759,9 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 		}
 	}
 
-	c.metrics.ConnectionsBackend.With("host", sanitizeUTF8(resolvedHost)).Add(1)
+	c.metrics.IncrementConnectionsBackend(sanitizeUTF8(resolvedHost))
 
-	c.metrics.ActiveConnections.Set(float64(
-		atomic.AddInt32(&c.totalActiveConnections, 1)))
+	c.metrics.SetActiveConnections(atomic.AddInt32(&c.totalActiveConnections, 1))
 
 	c.activeConnections.Increment(backendHostPort)
 	if scalingTarget != nil {
@@ -779,9 +775,9 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			cleanupCheckScaleDown = true
 		}
 	}
-	c.metrics.ServerActiveConnections.
-		With("server_address", sanitizeUTF8(serverAddress)).
-		Set(float64(c.activeConnections.GetCount(backendHostPort)))
+	c.metrics.SetServerActiveConnections(
+		sanitizeUTF8(serverAddress),
+		c.activeConnections.GetCount(backendHostPort))
 
 	if c.recordLogins && playerInfo != nil {
 		logrus.
@@ -790,17 +786,16 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			WithField("serverAddress", serverAddress).
 			Info("Player attempted to login to server")
 
-		c.metrics.ServerActivePlayer.
-			With("player_name", sanitizeUTF8(playerInfo.Name)).
-			With("player_uuid", sanitizeUTF8(playerInfo.Uuid.String())).
-			With("server_address", sanitizeUTF8(serverAddress)).
-			Set(1)
+		c.metrics.SetServerActivePlayerCounts(
+			sanitizeUTF8(playerInfo.Name),
+			sanitizeUTF8(playerInfo.Uuid.String()),
+			sanitizeUTF8(serverAddress),
+			1)
 
-		c.metrics.ServerLogins.
-			With("player_name", sanitizeUTF8(playerInfo.Name)).
-			With("player_uuid", sanitizeUTF8(playerInfo.Uuid.String())).
-			With("server_address", sanitizeUTF8(serverAddress)).
-			Add(1)
+		c.metrics.IncrementServerLogins(
+			sanitizeUTF8(playerInfo.Name),
+			sanitizeUTF8(playerInfo.Uuid.String()),
+			sanitizeUTF8(serverAddress))
 	}
 
 	cleanupMetrics = true
@@ -839,7 +834,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 				WithField("clientAddr", header.SourceAddr).
 				WithField("destAddr", header.DestinationAddr).
 				Error("Failed to write PROXY header")
-			c.metrics.Errors.With("type", "proxy_write").Add(1)
+			c.metrics.IncrementErrors("proxy_write")
 			_ = backendConn.Close()
 			return
 		}
@@ -848,7 +843,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 	amount, err := io.Copy(backendConn, preReadContent)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to write handshake to backend connection")
-		c.metrics.Errors.With("type", "backend_failed").Add(1)
+		c.metrics.IncrementErrors("backend_failed")
 		_ = backendConn.Close()
 		return
 	}
@@ -859,7 +854,7 @@ func (c *Connector) findAndConnectBackend(frontendConn net.Conn,
 			WithError(err).
 			WithField("client", clientAddr).
 			Error("Failed to clear read deadline")
-		c.metrics.Errors.With("type", "read_deadline").Add(1)
+		c.metrics.IncrementErrors("read_deadline")
 		_ = backendConn.Close()
 		return
 	}
@@ -885,7 +880,7 @@ func (c *Connector) pumpConnections(frontendConn, backendConn net.Conn, playerIn
 			logrus.WithError(err).
 				WithField("client", clientAddr).
 				Error("Error observed on connection relay")
-			c.metrics.Errors.With("type", "relay").Add(1)
+			c.metrics.IncrementErrors("relay")
 		}
 
 	case <-c.ctx.Done():
@@ -902,7 +897,7 @@ func (c *Connector) pumpFrames(incoming io.Reader, outgoing io.Writer, errors ch
 		WithField("player", playerInfo).
 		Infof("Finished relay %s->%s", from, to)
 
-	c.metrics.BytesTransmitted.Add(float64(amount))
+	c.metrics.AddBytesTransmitted(amount)
 
 	if err != nil {
 		errors <- err

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -83,7 +83,7 @@ type ConnectorMetrics struct {
 }
 
 func (cm *ConnectorMetrics) IncrementErrors(errorType string) {
-	cm.IncrementErrors(errorType)
+	cm.errorsCounter.With("type", errorType).Add(1)
 }
 
 func (cm *ConnectorMetrics) AddBytesTransmitted(amount int64) {

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/go-kit/kit/metrics"
 	"strings"
 	"time"
+
+	"github.com/go-kit/kit/metrics"
 
 	kitlogrus "github.com/go-kit/kit/log/logrus"
 	discardMetrics "github.com/go-kit/kit/metrics/discard"
@@ -70,29 +71,73 @@ func (b expvarMetricsBuilder) Start(ctx context.Context) error {
 }
 
 type ConnectorMetrics struct {
-	Errors                  metrics.Counter
-	BytesTransmitted        metrics.Counter
-	ConnectionsFrontend     metrics.Counter
-	ConnectionsBackend      metrics.Counter
-	ActiveConnections       metrics.Gauge
-	ServerActivePlayer      metrics.Gauge
-	ServerLogins            metrics.Counter
-	ServerActiveConnections metrics.Gauge
-	RateLimitAvailable      metrics.Gauge
+	errorsCounter           metrics.Counter
+	bytesTransmitted        metrics.Counter
+	connectionsFrontend     metrics.Counter
+	connectionsBackend      metrics.Counter
+	activeConnections       metrics.Gauge
+	serverActivePlayer      metrics.Gauge
+	serverLogins            metrics.Counter
+	serverActiveConnections metrics.Gauge
+	rateLimitAvailable      metrics.Gauge
+}
+
+func (cm *ConnectorMetrics) IncrementErrors(errorType string) {
+	cm.IncrementErrors(errorType)
+}
+
+func (cm *ConnectorMetrics) AddBytesTransmitted(amount int64) {
+	cm.bytesTransmitted.Add(float64(amount))
+}
+
+func (cm *ConnectorMetrics) IncrementConnectionsFrontend() {
+	cm.connectionsFrontend.Add(1)
+}
+
+// IncrementConnectionsBackend increments the counter for backend connections for the given host, which must be sanitized
+func (cm *ConnectorMetrics) IncrementConnectionsBackend(host string) {
+	cm.connectionsBackend.With("host", host).Add(1)
+}
+
+func (cm *ConnectorMetrics) SetActiveConnections(count int32) {
+	cm.activeConnections.Set(float64(count))
+}
+
+// SetServerActivePlayerCounts sets the count of active players for the given player and server, all of which must be sanitized
+func (cm *ConnectorMetrics) SetServerActivePlayerCounts(playerName string, playerUuid string, serverAddress string, count int) {
+	cm.serverActivePlayer.
+		With("player_name", playerName).
+		With("player_uuid", playerUuid).
+		With("server_address", serverAddress).
+		Set(float64(count))
+}
+
+// IncrementServerLogins increments the count of server logins for the given player and server, all of which must be sanitized
+func (cm *ConnectorMetrics) IncrementServerLogins(playerName string, playerUuid string, serverAddress string) {
+	cm.serverLogins.With("player_name", playerName).With("player_uuid", playerUuid).With("server_address", serverAddress).Add(1)
+}
+
+// SetServerActiveConnections sets the count of active connections for the given server, which must be sanitized
+func (cm *ConnectorMetrics) SetServerActiveConnections(serverAddress string, value int) {
+	cm.serverActiveConnections.With("server_address", serverAddress).Set(float64(value))
+}
+
+func (cm *ConnectorMetrics) SetRateLimitAvailable(value int64) {
+	cm.rateLimitAvailable.Set(float64(value))
 }
 
 func (b expvarMetricsBuilder) BuildConnectorMetrics() *ConnectorMetrics {
 	c := expvarMetrics.NewCounter("connections")
 	return &ConnectorMetrics{
-		Errors:                  expvarMetrics.NewCounter("errors").With("subsystem", "connector"),
-		BytesTransmitted:        expvarMetrics.NewCounter("bytes"),
-		ConnectionsFrontend:     c,
-		ConnectionsBackend:      c,
-		ActiveConnections:       expvarMetrics.NewGauge("active_connections"),
-		ServerActivePlayer:      expvarMetrics.NewGauge("server_active_player"),
-		ServerLogins:            expvarMetrics.NewCounter("server_logins"),
-		ServerActiveConnections: expvarMetrics.NewGauge("server_active_connections"),
-		RateLimitAvailable:      expvarMetrics.NewGauge("rate_limit_available"),
+		errorsCounter:           expvarMetrics.NewCounter("errors").With("subsystem", "connector"),
+		bytesTransmitted:        expvarMetrics.NewCounter("bytes"),
+		connectionsFrontend:     c,
+		connectionsBackend:      c,
+		activeConnections:       expvarMetrics.NewGauge("active_connections"),
+		serverActivePlayer:      expvarMetrics.NewGauge("server_active_player"),
+		serverLogins:            expvarMetrics.NewCounter("server_logins"),
+		serverActiveConnections: expvarMetrics.NewGauge("server_active_connections"),
+		rateLimitAvailable:      expvarMetrics.NewGauge("rate_limit_available"),
 	}
 }
 
@@ -106,15 +151,15 @@ func (b discardMetricsBuilder) Start(ctx context.Context) error {
 
 func (b discardMetricsBuilder) BuildConnectorMetrics() *ConnectorMetrics {
 	return &ConnectorMetrics{
-		Errors:                  discardMetrics.NewCounter(),
-		BytesTransmitted:        discardMetrics.NewCounter(),
-		ConnectionsFrontend:     discardMetrics.NewCounter(),
-		ConnectionsBackend:      discardMetrics.NewCounter(),
-		ActiveConnections:       discardMetrics.NewGauge(),
-		ServerActivePlayer:      discardMetrics.NewGauge(),
-		ServerLogins:            discardMetrics.NewCounter(),
-		ServerActiveConnections: discardMetrics.NewGauge(),
-		RateLimitAvailable:      discardMetrics.NewGauge(),
+		errorsCounter:           discardMetrics.NewCounter(),
+		bytesTransmitted:        discardMetrics.NewCounter(),
+		connectionsFrontend:     discardMetrics.NewCounter(),
+		connectionsBackend:      discardMetrics.NewCounter(),
+		activeConnections:       discardMetrics.NewGauge(),
+		serverActivePlayer:      discardMetrics.NewGauge(),
+		serverLogins:            discardMetrics.NewCounter(),
+		serverActiveConnections: discardMetrics.NewGauge(),
+		rateLimitAvailable:      discardMetrics.NewGauge(),
 	}
 }
 
@@ -159,15 +204,15 @@ func (b *influxMetricsBuilder) BuildConnectorMetrics() *ConnectorMetrics {
 
 	c := metrics.NewCounter("mc_router_connections")
 	return &ConnectorMetrics{
-		Errors:                  metrics.NewCounter("mc_router_errors"),
-		BytesTransmitted:        metrics.NewCounter("mc_router_transmitted_bytes"),
-		ConnectionsFrontend:     c.With("side", "frontend"),
-		ConnectionsBackend:      c.With("side", "backend"),
-		ActiveConnections:       metrics.NewGauge("mc_router_connections_active"),
-		ServerActivePlayer:      metrics.NewGauge("mc_router_server_player_active"),
-		ServerLogins:            metrics.NewCounter("mc_router_server_logins"),
-		ServerActiveConnections: metrics.NewGauge("mc_router_server_active_connections"),
-		RateLimitAvailable:      metrics.NewGauge("mc_router_rate_limit_available"),
+		errorsCounter:           metrics.NewCounter("mc_router_errors"),
+		bytesTransmitted:        metrics.NewCounter("mc_router_transmitted_bytes"),
+		connectionsFrontend:     c.With("side", "frontend"),
+		connectionsBackend:      c.With("side", "backend"),
+		activeConnections:       metrics.NewGauge("mc_router_connections_active"),
+		serverActivePlayer:      metrics.NewGauge("mc_router_server_player_active"),
+		serverLogins:            metrics.NewCounter("mc_router_server_logins"),
+		serverActiveConnections: metrics.NewGauge("mc_router_server_active_connections"),
+		rateLimitAvailable:      metrics.NewGauge("mc_router_rate_limit_available"),
 	}
 }
 
@@ -189,47 +234,47 @@ func (b prometheusMetricsBuilder) BuildConnectorMetrics() *ConnectorMetrics {
 		Help:      "The total number of errors",
 	}, []string{"type"}))
 	return &ConnectorMetrics{
-		Errors: pcv,
-		BytesTransmitted: prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
+		errorsCounter: pcv,
+		bytesTransmitted: prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "mc_router",
 			Name:      "bytes",
 			Help:      "The total number of bytes transmitted",
 		}, nil)),
-		ConnectionsFrontend: prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
+		connectionsFrontend: prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace:   "mc_router",
 			Subsystem:   "frontend",
 			Name:        "connections",
 			Help:        "The total number of connections",
 			ConstLabels: prometheus.Labels{"side": "frontend"},
 		}, nil)),
-		ConnectionsBackend: prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
+		connectionsBackend: prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace:   "mc_router",
 			Subsystem:   "backend",
 			Name:        "connections",
 			Help:        "The total number of backend connections",
 			ConstLabels: prometheus.Labels{"side": "backend"},
 		}, []string{"host"})),
-		ActiveConnections: prometheusMetrics.NewGauge(promauto.NewGaugeVec(prometheus.GaugeOpts{
+		activeConnections: prometheusMetrics.NewGauge(promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mc_router",
 			Name:      "active_connections",
 			Help:      "The number of active connections",
 		}, nil)),
-		ServerActivePlayer: prometheusMetrics.NewGauge(promauto.NewGaugeVec(prometheus.GaugeOpts{
+		serverActivePlayer: prometheusMetrics.NewGauge(promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mc_router",
 			Name:      "server_active_player",
 			Help:      "Player is active on server",
 		}, []string{"player_name", "player_uuid", "server_address"})),
-		ServerLogins: prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
+		serverLogins: prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "mc_router",
 			Name:      "server_logins",
 			Help:      "The total number of player logins",
 		}, []string{"player_name", "player_uuid", "server_address"})),
-		ServerActiveConnections: prometheusMetrics.NewGauge(promauto.NewGaugeVec(prometheus.GaugeOpts{
+		serverActiveConnections: prometheusMetrics.NewGauge(promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mc_router",
 			Name:      "server_active_connections",
 			Help:      "The number of active connections per server",
 		}, []string{"server_address"})),
-		RateLimitAvailable: prometheusMetrics.NewGauge(promauto.NewGaugeVec(prometheus.GaugeOpts{
+		rateLimitAvailable: prometheusMetrics.NewGauge(promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mc_router",
 			Name:      "rate_limit_available",
 			Help:      "The number of available tokens in the rate limit bucket",

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -189,6 +189,8 @@ func (b *influxMetricsBuilder) Start(ctx context.Context) error {
 	logrus.WithField("addr", influxConfig.Addr).
 		Debug("reporting metrics to influxdb")
 
+	logrus.Warn("InfluxDB support within mc-router is going to be removed in the future. Refer to https://github.com/itzg/mc-router/issues/615")
+
 	return nil
 }
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -21,7 +21,7 @@ import (
 )
 
 type MetricsBuilder interface {
-	BuildConnectorMetrics() *ConnectorMetrics
+	BuildConnectorMetrics() ConnectorMetrics
 	Start(ctx context.Context) error
 }
 
@@ -70,7 +70,19 @@ func (b expvarMetricsBuilder) Start(ctx context.Context) error {
 	return nil
 }
 
-type ConnectorMetrics struct {
+type ConnectorMetrics interface {
+	IncrementErrors(errorType string)
+	AddBytesTransmitted(amount int64)
+	IncrementConnectionsFrontend()
+	IncrementConnectionsBackend(host string)
+	SetActiveConnections(count int32)
+	SetServerActivePlayerCounts(playerName string, playerUuid string, serverAddress string, count int)
+	IncrementServerLogins(playerName string, playerUuid string, serverAddress string)
+	SetServerActiveConnections(serverAddress string, value int)
+	SetRateLimitAvailable(value int64)
+}
+
+type goKitConnectorMetrics struct {
 	errorsCounter           metrics.Counter
 	bytesTransmitted        metrics.Counter
 	connectionsFrontend     metrics.Counter
@@ -82,29 +94,29 @@ type ConnectorMetrics struct {
 	rateLimitAvailable      metrics.Gauge
 }
 
-func (cm *ConnectorMetrics) IncrementErrors(errorType string) {
+func (cm *goKitConnectorMetrics) IncrementErrors(errorType string) {
 	cm.errorsCounter.With("type", errorType).Add(1)
 }
 
-func (cm *ConnectorMetrics) AddBytesTransmitted(amount int64) {
+func (cm *goKitConnectorMetrics) AddBytesTransmitted(amount int64) {
 	cm.bytesTransmitted.Add(float64(amount))
 }
 
-func (cm *ConnectorMetrics) IncrementConnectionsFrontend() {
+func (cm *goKitConnectorMetrics) IncrementConnectionsFrontend() {
 	cm.connectionsFrontend.Add(1)
 }
 
 // IncrementConnectionsBackend increments the counter for backend connections for the given host, which must be sanitized
-func (cm *ConnectorMetrics) IncrementConnectionsBackend(host string) {
+func (cm *goKitConnectorMetrics) IncrementConnectionsBackend(host string) {
 	cm.connectionsBackend.With("host", host).Add(1)
 }
 
-func (cm *ConnectorMetrics) SetActiveConnections(count int32) {
+func (cm *goKitConnectorMetrics) SetActiveConnections(count int32) {
 	cm.activeConnections.Set(float64(count))
 }
 
 // SetServerActivePlayerCounts sets the count of active players for the given player and server, all of which must be sanitized
-func (cm *ConnectorMetrics) SetServerActivePlayerCounts(playerName string, playerUuid string, serverAddress string, count int) {
+func (cm *goKitConnectorMetrics) SetServerActivePlayerCounts(playerName string, playerUuid string, serverAddress string, count int) {
 	cm.serverActivePlayer.
 		With("player_name", playerName).
 		With("player_uuid", playerUuid).
@@ -113,22 +125,22 @@ func (cm *ConnectorMetrics) SetServerActivePlayerCounts(playerName string, playe
 }
 
 // IncrementServerLogins increments the count of server logins for the given player and server, all of which must be sanitized
-func (cm *ConnectorMetrics) IncrementServerLogins(playerName string, playerUuid string, serverAddress string) {
+func (cm *goKitConnectorMetrics) IncrementServerLogins(playerName string, playerUuid string, serverAddress string) {
 	cm.serverLogins.With("player_name", playerName).With("player_uuid", playerUuid).With("server_address", serverAddress).Add(1)
 }
 
 // SetServerActiveConnections sets the count of active connections for the given server, which must be sanitized
-func (cm *ConnectorMetrics) SetServerActiveConnections(serverAddress string, value int) {
+func (cm *goKitConnectorMetrics) SetServerActiveConnections(serverAddress string, value int) {
 	cm.serverActiveConnections.With("server_address", serverAddress).Set(float64(value))
 }
 
-func (cm *ConnectorMetrics) SetRateLimitAvailable(value int64) {
+func (cm *goKitConnectorMetrics) SetRateLimitAvailable(value int64) {
 	cm.rateLimitAvailable.Set(float64(value))
 }
 
-func (b expvarMetricsBuilder) BuildConnectorMetrics() *ConnectorMetrics {
+func (b expvarMetricsBuilder) BuildConnectorMetrics() ConnectorMetrics {
 	c := expvarMetrics.NewCounter("connections")
-	return &ConnectorMetrics{
+	return &goKitConnectorMetrics{
 		errorsCounter:           expvarMetrics.NewCounter("errors").With("subsystem", "connector"),
 		bytesTransmitted:        expvarMetrics.NewCounter("bytes"),
 		connectionsFrontend:     c,
@@ -149,8 +161,8 @@ func (b discardMetricsBuilder) Start(ctx context.Context) error {
 	return nil
 }
 
-func (b discardMetricsBuilder) BuildConnectorMetrics() *ConnectorMetrics {
-	return &ConnectorMetrics{
+func (b discardMetricsBuilder) BuildConnectorMetrics() ConnectorMetrics {
+	return &goKitConnectorMetrics{
 		errorsCounter:           discardMetrics.NewCounter(),
 		bytesTransmitted:        discardMetrics.NewCounter(),
 		connectionsFrontend:     discardMetrics.NewCounter(),
@@ -183,6 +195,9 @@ func (b *influxMetricsBuilder) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create influx http client: %w", err)
 	}
+	context.AfterFunc(ctx, func() {
+		_ = client.Close()
+	})
 
 	go b.metrics.WriteLoop(ctx, ticker.C, client)
 
@@ -194,27 +209,27 @@ func (b *influxMetricsBuilder) Start(ctx context.Context) error {
 	return nil
 }
 
-func (b *influxMetricsBuilder) BuildConnectorMetrics() *ConnectorMetrics {
+func (b *influxMetricsBuilder) BuildConnectorMetrics() ConnectorMetrics {
 	influxConfig := &b.config.Influxdb
 
-	metrics := kitinflux.New(influxConfig.Tags, influx.BatchPointsConfig{
+	influxClient := kitinflux.New(influxConfig.Tags, influx.BatchPointsConfig{
 		Database:        influxConfig.Database,
 		RetentionPolicy: influxConfig.RetentionPolicy,
 	}, kitlogrus.NewLogger(logrus.StandardLogger()))
 
-	b.metrics = metrics
+	b.metrics = influxClient
 
-	c := metrics.NewCounter("mc_router_connections")
-	return &ConnectorMetrics{
-		errorsCounter:           metrics.NewCounter("mc_router_errors"),
-		bytesTransmitted:        metrics.NewCounter("mc_router_transmitted_bytes"),
+	c := influxClient.NewCounter("mc_router_connections")
+	return &goKitConnectorMetrics{
+		errorsCounter:           influxClient.NewCounter("mc_router_errors"),
+		bytesTransmitted:        influxClient.NewCounter("mc_router_transmitted_bytes"),
 		connectionsFrontend:     c.With("side", "frontend"),
 		connectionsBackend:      c.With("side", "backend"),
-		activeConnections:       metrics.NewGauge("mc_router_connections_active"),
-		serverActivePlayer:      metrics.NewGauge("mc_router_server_player_active"),
-		serverLogins:            metrics.NewCounter("mc_router_server_logins"),
-		serverActiveConnections: metrics.NewGauge("mc_router_server_active_connections"),
-		rateLimitAvailable:      metrics.NewGauge("mc_router_rate_limit_available"),
+		activeConnections:       influxClient.NewGauge("mc_router_connections_active"),
+		serverActivePlayer:      influxClient.NewGauge("mc_router_server_player_active"),
+		serverLogins:            influxClient.NewCounter("mc_router_server_logins"),
+		serverActiveConnections: influxClient.NewGauge("mc_router_server_active_connections"),
+		rateLimitAvailable:      influxClient.NewGauge("mc_router_rate_limit_available"),
 	}
 }
 
@@ -229,13 +244,13 @@ func (b prometheusMetricsBuilder) Start(ctx context.Context) error {
 	return nil
 }
 
-func (b prometheusMetricsBuilder) BuildConnectorMetrics() *ConnectorMetrics {
+func (b prometheusMetricsBuilder) BuildConnectorMetrics() ConnectorMetrics {
 	pcv = prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "mc_router",
 		Name:      "errors",
 		Help:      "The total number of errors",
 	}, []string{"type"}))
-	return &ConnectorMetrics{
+	return &goKitConnectorMetrics{
 		errorsCounter: pcv,
 		bytesTransmitted: prometheusMetrics.NewCounter(promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "mc_router",


### PR DESCRIPTION
go-kit is a bloated set of depenencies and no longer the prevailing way to expose metrics, such as for Prometheus. As such, this PR is the first step abstract the increment/set/add operations behind methods.

The goal is to switch to go.opentelemetry.io/otel with go.opentelemetry.io/otel/exporters/prometheus.

InfluxDB will probably be the trickier one since there isn't a otel exporter for that. Ideally an otel collector exporter option would allow users to backfill that.